### PR TITLE
Untitled

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -207,5 +207,6 @@ if getattr(settings, 'MPTT_USE_FEINCMS', True):
 
             def get_actions(self, request):
                 actions = super(FeinCMSModelAdmin, self).get_actions(request)
-                actions['delete_selected'] = (self.delete_selected_tree, 'delete_selected', _("Delete selected %(verbose_name_plural)s"))
+                if 'delete_selected' in actions:
+                    actions['delete_selected'] = (self.delete_selected_tree, 'delete_selected', _("Delete selected %(verbose_name_plural)s"))
                 return actions


### PR DESCRIPTION
Hi, I ran into this problem when displaying the MPTT changelist in a popup (Django's ForeignKeyRawIdWidget). It seems that get_actions() then returns an empty list [], not a dictionary, and then an exception is caused when trying to use a string key with that list. This fixes it.
