### PR TITLE
Added a 'fields' file that can contain mptt model fields.

### DIFF
--- a/mptt/fields.py
+++ b/mptt/fields.py
@@ -21,3 +21,10 @@ class TreeForeignKey(models.ForeignKey):
         defaults = {'form_class': TreeNodeChoiceField}
         defaults.update(kwargs)
         return super(TreeForeignKey, self).formfield(**defaults)
+
+# South integration for the TreeForeignKey
+try:
+    from south.modelsinspector import add_introspection_rules
+    add_introspection_rules([], ["^mptt\.fields\.TreeForeignKey"])
+except ImportError:
+    pass


### PR DESCRIPTION
This file includes an extension to the ForeignKey field that uses mptt's TreeNodeChoiceField by default.

This is really handy if you're using models that need to use the correct form widget for a field when a ModelForm instance is automatically generated.
