### PR TITLE
possible fix for #137

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -42,7 +42,7 @@ class MPTTModelAdmin(ModelAdmin):
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         from mptt.models import MPTTModel
         if issubclass(db_field.rel.to, MPTTModel):
-            return TreeNodeChoiceField(queryset=db_field.rel.to.objects.all(),
+            return db_field.formfield(queryset=db_field.rel.to.objects.all(),
                                        required=False)
         return super(MPTTModelAdmin, self).formfield_for_foreignkey(db_field,
                                                                     request,


### PR DESCRIPTION
Seems like it should not break anything, and still enable verbose_name and other options to be passed to admin form field for self relations.
