### PR TITLE
Fix inline editing in django 1.3 admin

### DIFF
--- a/mptt/templatetags/mptt_admin.py
+++ b/mptt/templatetags/mptt_admin.py
@@ -8,7 +8,7 @@ from django.utils.safestring import mark_safe
 from django.utils.encoding import smart_unicode, force_unicode
 from django.template import Library
 
-from django.contrib.admin.templatetags.admin_list import _boolean_icon, result_headers
+from django.contrib.admin.templatetags.admin_list import _boolean_icon, result_headers, result_hidden_fields
 
 
 register = Library()
@@ -145,6 +145,7 @@ def mptt_result_list(cl):
     Displays the headers and data list together
     """
     return {'cl': cl,
+            'result_hidden_fields': list(result_hidden_fields(cl)),
             'result_headers': list(result_headers(cl)),
             'results': list(mptt_results(cl))}
 


### PR DESCRIPTION
Fix django-mptt to allow inline editing in django admin with django 1.3
see https://code.djangoproject.com/changeset/13744/django/trunk/django/contrib/admin/templatetags/admin_list.py 
for related change in django
