### PR TITLE
Modified get_siblings to make including root siblings optional

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -503,17 +503,21 @@ class MPTTModel(models.Model):
             parent__isnull=True
         ).get()
 
-    def get_siblings(self, include_self=False):
+    def get_siblings(self, include_self=False, root_siblings=True):
         """
         Creates a ``QuerySet`` containing siblings of this model
-        instance. Root nodes are considered to be siblings of other root
-        nodes.
+        instance.
+
+        If ``root_siblings`` is ``True``, root nodes are considered to be
+        siblings of other root nodes.
 
         If ``include_self`` is ``True``, the ``QuerySet`` will also
         include this model instance.
         """
         if self.is_root_node():
             queryset = self._tree_manager._mptt_filter(parent__isnull=True)
+            if not root_siblings:
+                queryset = queryset.filter(tree_id=self.tree_id)
         else:
             parent_id = getattr(self, '%s_id' % self._mptt_meta.parent_attr)
             queryset = self._tree_manager._mptt_filter(parent__id=parent_id)

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -346,3 +346,18 @@ class InterTreeMovementTestCase(TestCase):
 
 class PositionedInsertionTestCase(TestCase):
     pass
+
+
+class QueriesTestCase(TestCase):
+    """ Tests that node queries behave as expected. """
+    fixtures = ['genres.json']
+
+    def test_get_siblings_with_root_siblings(self):
+        action = Genre.objects.get(pk=1)
+        siblings = action.get_siblings()
+        self.assertEqual(siblings.count(), 1)
+
+    def test_get_siblings_without_root_siblings(self):
+        action = Genre.objects.get(pk=1)
+        siblings = action.get_siblings(root_siblings=False)
+        self.assertEqual(siblings.count(), 0)


### PR DESCRIPTION
This is a very small patch (with tests) that modifies get_siblings to make the inclusion of root nodes optional. If root_siblings is False, root siblings are not returned. The default behaviour is to include root siblings.

My app uses multiple trees so I needed to be able to exclude root siblings. This seemed the cleanest way to implement it without doing an additional "is this the root node, then exclude siblings" check in my own app.

Although a small change, I would appreciate it if this could be merged so I can continue using the official version of django-mptt.

Thanks,

Mike
