### PR TITLE
`_cached_children` attribute is list, expecting a queryset

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -374,7 +374,7 @@ class MPTTModel(models.Model):
 
         return qs.order_by(order_by)
 
-    def get_children(self, from_cache=True):
+    def get_children(self):
         """
         Returns a ``QuerySet`` containing the immediate children of this
         model instance, in tree order.
@@ -388,7 +388,9 @@ class MPTTModel(models.Model):
         ``cache_tree_children`` filter, no database query is required.
         """
 
-        if hasattr(self, '_cached_children') and from_cache:
+        if hasattr(self, '_cached_children'):
+            if not isinstance(self._cached_children, models.query.QuerySet): 
+                self._cached_children = self.__class__.objects.filter(id__in=self._cached_children)
             return self._cached_children
         else:
             if self.is_leaf_node():


### PR DESCRIPTION
The template filter cache_tree_children ends up caching the children as a list, and subsequent calls to get_children() returns this cached list. Therefore any code that expects a queryset from get_children() will succeed before and fail after.

Not sure if a kwarg is an ideal solution, but I thought the list behavior was a bit odd to start with.
