### PR TITLE
Made it possible to override the default TreeManager

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -273,7 +273,7 @@ class MPTTModelBase(ModelBase):
                     manager.init_from_model(cls)
 
                 # make sure we have a tree manager somewhere
-                tree_manager = TreeManager()
+                tree_manager = getattr(cls, 'tree', TreeManager())
                 tree_manager.contribute_to_class(cls, '_tree_manager')
                 tree_manager.init_from_model(cls)
 


### PR DESCRIPTION
Allowed explicit definition of a `tree` attribute in MTTModel subclasses that is used instead of TreeManager if it is set.

This is a suggested solution the problem discussed in #107

I'm not sure if it is a good solution but it is one that worked for me and given my understanding of django-mptt I can not see any obvious negative implications.
