### PR TITLE
Update the mptt fields in the cached parent when saving existing object

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -663,6 +663,17 @@ class MPTTModel(models.Model):
                     if opts.order_insertion_by:
                         right_sibling = opts.get_ordered_insertion_target(self, getattr(self, opts.parent_attr))
 
+                    if parent_id is not None:
+                        parent = getattr(self, opts.parent_attr)
+                        # If we aren't already a descendant of the new parent, we need to update the parent.rght so
+                        # things like get_children and get_descendant_count work correctly.
+                        if (getattr(self, opts.tree_id_attr) != getattr(parent, opts.tree_id_attr) or
+                            getattr(self, opts.left_attr) < getattr(parent, opts.left_attr) or
+                            getattr(self, opts.right_attr) > getattr(parent, opts.right_attr)):
+                            update_cached_parent = True
+                        else:
+                            update_cached_parent = False
+
                     if right_sibling:
                         self.move_to(right_sibling, 'left')
                     else:
@@ -675,8 +686,12 @@ class MPTTModel(models.Model):
                             except IndexError:
                                 pass
                         else:
-                            parent = getattr(self, opts.parent_attr)
                             self.move_to(parent, position='last-child')
+
+                    if parent_id is not None and update_cached_parent:
+                        # Update rght of cached parent
+                        right_shift = 2 * (self.get_descendant_count() + 1)
+                        self._tree_manager._post_insert_update_cached_parent_right(parent, right_shift)
                 finally:
                     # Make sure the new parent is always
                     # restored on the way out in case of errors.

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -118,6 +118,7 @@ class ReparentingTestCase(TestCase):
         action.parent = rpg
         action.save()
         self.assertEqual(get_tree_details([action]), '1 9 2 1 6 21')
+        self.assertEqual(get_tree_details([rpg]), '9 - 2 0 1 22')
         self.assertEqual(get_tree_details(Genre.objects.all()),
                          tree_details("""9 - 2 0 1 22
                                          10 9 2 1 2 3
@@ -137,6 +138,7 @@ class ReparentingTestCase(TestCase):
         shmup_horizontal.parent = rpg
         shmup_horizontal.save()
         self.assertEqual(get_tree_details([shmup_horizontal]), '8 9 2 1 6 7')
+        self.assertEqual(get_tree_details([rpg]), '9 - 2 0 1 8')
         self.assertEqual(get_tree_details(Genre.objects.all()),
                          tree_details("""1 - 1 0 1 14
                                          2 1 1 1 2 9
@@ -156,6 +158,7 @@ class ReparentingTestCase(TestCase):
         shmup.parent = trpg
         shmup.save()
         self.assertEqual(get_tree_details([shmup]), '6 11 2 2 5 10')
+        self.assertEqual(get_tree_details([trpg]), '11 9 2 1 4 11')
         self.assertEqual(get_tree_details(Genre.objects.all()),
                          tree_details("""1 - 1 0 1 10
                                          2 1 1 1 2 9
@@ -175,6 +178,7 @@ class ReparentingTestCase(TestCase):
         shmup_horizontal.parent = action
         shmup_horizontal.save()
         self.assertEqual(get_tree_details([shmup_horizontal]), '8 1 1 1 14 15')
+        self.assertEqual(get_tree_details([action]), '1 - 1 0 1 16')
         self.assertEqual(get_tree_details(Genre.objects.all()),
                          tree_details("""1 - 1 0 1 16
                                          2 1 1 1 2 9
@@ -194,6 +198,7 @@ class ReparentingTestCase(TestCase):
         shmup.parent = platformer
         shmup.save()
         self.assertEqual(get_tree_details([shmup]), '6 2 1 2 9 14')
+        self.assertEqual(get_tree_details([platformer]), '2 1 1 1 2 15')
         self.assertEqual(get_tree_details(Genre.objects.all()),
                          tree_details("""1 - 1 0 1 16
                                          2 1 1 1 2 15


### PR DESCRIPTION
We didn't update the parent mptt fields when saving an existing object like we do when creating it, resulting in that this worked as expected:

``` python
parent = Node.objects.create()
child = Node.objects.create(parent=parent)
parent.get_children()
```

but this didn't:

``` python
parent = Node.objects.create()
child = Node.objects.create()
child.parent = parent
child.save()
parent.get_children()
```

This patch checks whether we are already a descendant of the new parent and updates the mptt fields in the cached parent if we aren't. I've also added checks for this to the reparenting test cases.
