### PR TITLE
FeinCMSModelAdmin compatibility with Django 1.4 admin images

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -200,9 +200,10 @@ if getattr(settings, 'MPTT_USE_FEINCMS', True):
 
             def _actions_column(self, obj):
                 actions = super(FeinCMSModelAdmin, self)._actions_column(obj)
-                # compatibility with Django 1.4 admin images
+                # compatibility with Django 1.4 admin images (issue #191):
+                # https://docs.djangoproject.com/en/1.4/releases/1.4/#django-contrib-admin
                 if django.VERSION >= (1, 4):
-                    admin_img_prefix = "%simg/" % settings.ADMIN_MEDIA_PREFIX
+                    admin_img_prefix = "%sadmin/img/" % settings.STATIC_URL
                 else:
                     admin_img_prefix = "%simg/admin/" % settings.ADMIN_MEDIA_PREFIX
                 actions.insert(0,

--- a/mptt/forms.py
+++ b/mptt/forms.py
@@ -164,7 +164,7 @@ class MoveNodeForm(forms.Form):
 class MPTTAdminForm(forms.ModelForm):
     """
     A form which validates that the chosen parent for a node isn't one of
-    it's descendants.
+    its descendants.
     """
     def clean(self):
         cleaned_data = super(MPTTAdminForm, self).clean()

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -1,5 +1,7 @@
 import re
 
+import django
+from django.contrib import admin
 from django.test import TestCase
 
 from mptt.exceptions import InvalidMove
@@ -346,3 +348,30 @@ class InterTreeMovementTestCase(TestCase):
 
 class PositionedInsertionTestCase(TestCase):
     pass
+
+
+class FeinCMSModelAdminTestCase(TestCase):
+    """
+    Tests for FeinCMSModelAdmin.
+    """
+    fixtures = ['categories.json']
+
+    def setUp(self):
+        from mptt.admin import FeinCMSModelAdmin
+        self.model_admin = FeinCMSModelAdmin(Category, admin.site)
+
+    def test_actions_column(self):
+        """
+        The action column should have an "add" button inserted.
+        """
+        # See implementation notes.
+        if django.VERSION < (1, 4):
+            prefix = '/static/admin/img/admin/'
+        else:
+            prefix = '/static/admin/img/'
+
+        category = Category.objects.get(id=1)
+        self.assertEqual(self.model_admin._actions_column(category), [
+            u'<a href="add/?parent=1" title="Add child">'
+                u'<img src="%sicon_addlink.gif" alt="Add child" /></a>' % prefix,
+            '<div class="drag_handle"></div>'])

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,3 +17,6 @@ INSTALLED_APPS = (
     'mptt',
     'myapp',
 )
+
+# Required for Django 1.4+
+STATIC_URL = '/static/'

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,7 @@
 [tox]
 envlist=py24,py25,py26,py27
 [testenv]
-commands=python setup.py test
+deps =
+    FeinCMS
+changedir = {toxinidir}/tests
+commands = ./runtests.sh


### PR DESCRIPTION
Django 1.4[+] now holds admin images on "img/" instead of "admin/img/"
