### PR TITLE
Fixes wrong order for cache_tree_children

### DIFF
--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -11,6 +11,7 @@ class CustomTreeManager(TreeManager):
 class Category(MPTTModel):
     name = models.CharField(max_length=50)
     parent = models.ForeignKey('self', null=True, blank=True, related_name='children')
+    is_published = models.BooleanField(default=False)
 
     def __unicode__(self):
         return self.name


### PR DESCRIPTION
For example, I have a tree (plus means is published, minus means is unpublished):

```
    - Shop
        + Apparel & Accessories
            - Subcategory (Apparel & Accessories)
        - Automobiles & Motorcycles
            + Subcategory (Automobiles & Motorcycles)
```

I want to show only published categories with cache_tree_children and will get like that:

```
    + Apparel & Accessories
    + Subcategory (Automobiles & Motorcycles)
```

Tests included.
