### PR TITLE
Remove superfluous and deprecated tag library usage

### DIFF
--- a/mptt/templates/admin/mptt_change_list.html
+++ b/mptt/templates/admin/mptt_change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load adminmedia admin_list i18n mptt_admin %}
+{% load admin_list i18n mptt_admin %}
 
 {% block result_list %}
     {% if action_form and actions_on_top and cl.full_result_count %}{% admin_actions %}{% endif %}


### PR DESCRIPTION
There is adminmedia templatetag library loaded in one template. This library has only one tag, admin_media_prefix, which is not used there. This library gets removed in django 1.5.

This pull requests removed the unnecessary load, which makes the library good to run with django 1.5.
