### PR TITLE
Added notice about Model's multi-inheritance

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -25,6 +25,13 @@ Because you're inheriting from MPTTModel, your model will also have a number of
 other fields: ``level``, ``lft``, ``rght``, and ``tree_id``. Most of the time
 you won't need to use these fields directly, but it's helpful to know they're there.
 
+Please note that if you are using multi-inheritance, MPTTModel should usually be the first class to be inherited from::
+
+    class Genre(MPTTModel,Foo,Bar):
+        name = models.CharField(max_length=50, unique=True)
+
+Since MPTTModel inherits from ``models.Model``, this is very important when you have "diamond-style" multiple inheritance : you inherit from two Models that both inherit from the same base class (e.g. ``models.Model``) . In that case, If MPTTModel is not the first Model, you may get errors at Model validation, like ``AttributeError: 'NoneType' object has no attribute 'name'``.
+
 Model Options
 =============
 


### PR DESCRIPTION
When using multi-inheritance, MPTTModel should usually be the first class to be inherited from.
