### PR TITLE
Fix list_display handling.

### DIFF
--- a/mptt/templatetags/mptt_admin.py
+++ b/mptt/templatetags/mptt_admin.py
@@ -43,11 +43,9 @@ def mptt_items_for_result(cl, result, form):
             try:
                 f = cl.lookup_opts.get_field(field_name)
             except models.FieldDoesNotExist:
-                if mptt_indent_field is None:
-                    attr = getattr(result, field_name, None)
-                    if callable(attr):
-                        # first callable field, use this if we can't find any model fields
-                        mptt_indent_field = field_name
+                if (mptt_indent_field is None and
+                    field_name != 'action_checkbox'):
+                    mptt_indent_field = field_name
             else:
                 # first model field, use this one
                 mptt_indent_field = field_name


### PR DESCRIPTION
The django documentation for list_display lists four ways of specifying
elements: field names, callables, admin methods and model methods.

The current code in templatetags/mptt-admin.py takes only field names and
model methods into account: When the element is a callable, it throws a
ValueError in getattr(), when it is an admin method, it ignores it.

This commit fixes the issue #228 by just using any field_name except
'action_checkbox' as mptt_indent_field.
