### PR TITLE
Documentation fix for issue #236

### DIFF
--- a/docs/technical_details.rst
+++ b/docs/technical_details.rst
@@ -82,6 +82,25 @@ of nodes which are retrieved for the whole tree or any subtree::
    node.get_descendants().filter(level__lte=node.level + 2)
 
 
+Concurrency
+===========
+
+Most CRUD methods involve the execution of multiple queries. These
+methods need to be made mutually exclusive, otherwise corrupt hierarchies might get created.
+Mutual exclusivity is usually achieved by placing the queries between
+**LOCK TABLE** and **UNLOCK TABLE** statements. However, mptt
+can't do the locking itself because the `LOCK/UNLOCK statements are not transaction safe`_
+and would therefore mess up the client code's transactions. This means that it's
+the client code's responsibility to ensure that calls to mptt CRUD methods are mutually
+exclusive.
+
+Note: In the above paragraph 'client code' means any django app that uses mptt base models.
+
+.. _`LOCK/UNLOCK statements are not transaction safe`: http://dev.mysql.com/doc/refman/5.0/en/lock-tables-and-transactions.html
+
+ 
+
+
 Running the test suite
 ======================
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -28,7 +28,7 @@ The Solution
 
 Modified Preorder Tree Traversal can be a bit daunting at first, but it's one of the best ways to solve this problem.
 
-If you want to go into the details, there's a good explanation here: `Storing Hierarchical Data in a Database`_
+If you want to go into the details, there's a good explanation here: `Storing Hierarchical Data in a Database`_ or `Managing Hierarchical Data in Mysql`_
 
 tl;dr: MPTT makes most tree operations much cheaper in terms of queries. In fact all these operations take at most one query, and sometimes zero:
  * get descendants of a node
@@ -40,6 +40,7 @@ And this one takes zero queries:
  * count the descendants of a given node
 
 .. _`Storing Hierarchical Data in a Database`: http://www.sitepoint.com/hierarchical-data-database/
+.. _`Managing Hierarchical Data in Mysql`: http://mikehillyer.com/articles/managing-hierarchical-data-in-mysql/
 
 Enough intro. Let's get started.
 


### PR DESCRIPTION
Provide a section in the documentation that warns mptt users about the concurrency issues and about the fact that it's their responsibility for ensuring mutual exclusivity.
- this fixes issue #236
- also add a new link to an mptt tutorial (I find this more usefull than the existing ones as it also points out that CRUD operations need to be guarded by locking statements)
