### PR TITLE
Add an 'all' argument to drilldown_tree_for_node

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -96,8 +96,8 @@ Populates a template variable with the drilldown tree for a given node,
 optionally counting the number of items associated with its children.
 
 A drilldown tree consists of a node's ancestors, itself and its
-immediate children. For example, a drilldown tree for a book category
-"Personal Finance" might look something like::
+immediate children or all descendants. For example, a drilldown tree
+for a book category "Personal Finance" might look something like::
 
    Books
       Business, Finance & Law
@@ -111,6 +111,7 @@ Usage::
 
 Extended usage::
 
+   {% drilldown_tree_for_node [node] as [varname] all %}
    {% drilldown_tree_for_node [node] as [varname] count [foreign_key] in [count_attr] %}
    {% drilldown_tree_for_node [node] as [varname] cumulative count [foreign_key] in [count_attr] %}
 

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -62,7 +62,7 @@ It creates an iterable which yields model instances representing a
 drilldown tree for a given node.
 
 A drilldown tree consists of a node's ancestors, itself and its
-immediate children, all in tree order.
+immediate children or all descendants, all in tree order.
 
 Optional arguments may be given to specify details of a relationship
 between the given node's class and another model class, for the

--- a/mptt/templatetags/mptt_tags.py
+++ b/mptt/templatetags/mptt_tags.py
@@ -33,12 +33,13 @@ class FullTreeForModelNode(template.Node):
 
 class DrilldownTreeForNodeNode(template.Node):
     def __init__(self, node, context_var, foreign_key=None, count_attr=None,
-                 cumulative=False):
+                 cumulative=False, all_descendants=False):
         self.node = template.Variable(node)
         self.context_var = context_var
         self.foreign_key = foreign_key
         self.count_attr = count_attr
         self.cumulative = cumulative
+        self.all_descendants = all_descendants
 
     def render(self, context):
         # Let any VariableDoesNotExist raised bubble up
@@ -60,7 +61,7 @@ class DrilldownTreeForNodeNode(template.Node):
                 )
             args.extend([cls, fk_attr, self.count_attr, self.cumulative])
 
-        context[self.context_var] = drilldown_tree_for_node(*args)
+        context[self.context_var] = drilldown_tree_for_node(*args, all_descendants=self.all_descendants)
         return ''
 
 
@@ -97,8 +98,8 @@ def do_drilldown_tree_for_node(parser, token):
     children.
 
     A drilldown tree consists of a node's ancestors, itself and its
-    immediate children. For example, a drilldown tree for a book
-    category "Personal Finance" might look something like::
+    immediate children or all descendants. For example, a drilldown tree
+    for a book category "Personal Finance" might look something like::
 
        Books
           Business, Finance & Law
@@ -112,6 +113,7 @@ def do_drilldown_tree_for_node(parser, token):
 
     Extended usage::
 
+       {% drilldown_tree_for_node [node] as [varname] all %}
        {% drilldown_tree_for_node [node] as [varname] count [foreign_key] in [count_attr] %}
        {% drilldown_tree_for_node [node] as [varname] cumulative count [foreign_key] in [count_attr] %}
 
@@ -135,12 +137,20 @@ def do_drilldown_tree_for_node(parser, token):
     """
     bits = token.contents.split()
     len_bits = len(bits)
-    if len_bits not in (4, 8, 9):
+    if len_bits not in (4, 5, 8, 9, 10):
         raise template.TemplateSyntaxError(
-            _('%s tag requires either three, seven or eight arguments') % bits[0])
+            _('%s tag requires either three, four, seven, eight, or nine arguments') % bits[0])
     if bits[2] != 'as':
         raise template.TemplateSyntaxError(
             _("second argument to %s tag must be 'as'") % bits[0])
+
+    all_descendants = False
+    if len_bits > 4:
+        if bits[4] == 'all':
+            len_bits -= 1
+            bits.pop(4)
+            all_descendants = True
+
     if len_bits == 8:
         if bits[4] != 'count':
             raise template.TemplateSyntaxError(
@@ -148,7 +158,7 @@ def do_drilldown_tree_for_node(parser, token):
         if bits[6] != 'in':
             raise template.TemplateSyntaxError(
                 _("if seven arguments are given, sixth argument to %s tag must be 'in'") % bits[0])
-        return DrilldownTreeForNodeNode(bits[1], bits[3], bits[5], bits[7])
+        return DrilldownTreeForNodeNode(bits[1], bits[3], bits[5], bits[7], all_descendants=all_descendants)
     elif len_bits == 9:
         if bits[4] != 'cumulative':
             raise template.TemplateSyntaxError(
@@ -159,9 +169,9 @@ def do_drilldown_tree_for_node(parser, token):
         if bits[7] != 'in':
             raise template.TemplateSyntaxError(
                 _("if eight arguments are given, seventh argument to %s tag must be 'in'") % bits[0])
-        return DrilldownTreeForNodeNode(bits[1], bits[3], bits[6], bits[8], cumulative=True)
+        return DrilldownTreeForNodeNode(bits[1], bits[3], bits[6], bits[8], cumulative=True, all_descendants=all_descendants)
     else:
-        return DrilldownTreeForNodeNode(bits[1], bits[3])
+        return DrilldownTreeForNodeNode(bits[1], bits[3], all_descendants=all_descendants)
 
 
 @register.filter

--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -108,11 +108,11 @@ def tree_item_iterator(items, ancestors=False):
 
 
 def drilldown_tree_for_node(node, rel_cls=None, rel_field=None, count_attr=None,
-                            cumulative=False):
+                            cumulative=False, all_descendants=False):
     """
     Creates a drilldown tree for the given node. A drilldown tree
-    consists of a node's ancestors, itself and its immediate children,
-    all in tree order.
+    consists of a node's ancestors, itself and its immediate children
+    or all descendants, all in tree order.
 
     Optional arguments may be given to specify a ``Model`` class which
     is related to the node's class, for the purpose of adding related
@@ -133,12 +133,17 @@ def drilldown_tree_for_node(node, rel_cls=None, rel_field=None, count_attr=None,
     ``cumulative``
        If ``True``, the count will be for each child and all of its
        descendants, otherwise it will be for each child itself.
+
+    ``all_descendants``
+       If ``True``, return all descendants, not just immediate children.
     """
-    if rel_cls and rel_field and count_attr:
-        children = node._tree_manager.add_related_count(
-            node.get_children(), rel_cls, rel_field, count_attr, cumulative)
+    if all_descendants:
+        children = node.get_descendants()
     else:
         children = node.get_children()
+    if rel_cls and rel_field and count_attr:
+        children = node._tree_manager.add_related_count(
+            children, rel_cls, rel_field, count_attr, cumulative)
     return itertools.chain(node.get_ancestors(), [node], children)
 
 


### PR DESCRIPTION
This adds a new optional argument (immediately after the required arguments) to have the function return all descendants of the node, not just its immediate children.

I added this because I wanted the cumulative count functionality of drilldown_tree_for_node, but wanted to show all the descendants of a particular node, not just its children. I'm not sure if there's a different/better way I could have done this, feel free to let me know :)