### PR TITLE
Filter the invalid parents in the MPTTAdminForm

### DIFF
--- a/mptt/forms.py
+++ b/mptt/forms.py
@@ -160,13 +160,12 @@ class MPTTAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super(MPTTAdminForm, self).__init__(*args, **kwargs)
         if self.instance and self.instance.pk:
-            parent_field = self._meta.model._mptt_meta.parent_attr
+            instance = self.instance
+            opts = self._meta.model._mptt_meta
+            parent_field = opts.parent_attr
             parent_qs = self.fields[parent_field].queryset
-            parent_qs = parent_qs.exclude(pk=self.instance.pk)
-            descendants = self.instance.get_descendants()
-            if descendants.exists():
-                descendants_pks = descendants.values('pk').query
-                parent_qs = parent_qs.exclude(pk__in=descendants_pks)
+            exclude_pks = instance.get_descendants(include_self=True).values('pk').query
+            parent_qs = parent_qs.exclude(pk__in=exclude_pks)
             self.fields[parent_field].queryset = parent_qs
 
     def clean(self):


### PR DESCRIPTION
Filter the invalid parents in the MPTTAdminForm.

I think that now, we could delete the clean method of the MPTTAdminForm class.
