### PR TITLE
Fix exception in MPTTAdminForm

### DIFF
--- a/mptt/forms.py
+++ b/mptt/forms.py
@@ -164,7 +164,11 @@ class MPTTAdminForm(forms.ModelForm):
             opts = self._meta.model._mptt_meta
             parent_field = self.fields[opts.parent_attr]
             parent_qs = parent_field.queryset
-            parent_qs = parent_qs.exclude(instance.get_descendants(include_self=True))
+            parent_qs = parent_qs.exclude(
+                pk__in=instance.get_descendants(
+                    include_self=True
+                ).values_list('pk', flat=True)
+            )
             parent_field.queryset = parent_qs
 
     def clean(self):


### PR DESCRIPTION
`exclude` requires a kwarg to filter on.

When I tried to view a model that used MPTTAdminForm I got an `AttributeError 'Folder' object has no attribute 'split'`. Looking at the history of that code it seems like a refactor accidentally introduced a bug.

Tested with Django 1.5.1.

Again sorry for closing the previous pull request. I'm doing a second request, which is a feature request, so I didn't want them to be tangled up together.
