### PR TITLE
Add node_moved signal to be sent after node successfully moved

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -227,7 +227,8 @@ otherwise.
 -------------------------------------------
 
 Moves the model instance elsewhere in the tree based on ``target`` and
-``position`` (when appropriate).
+``position`` (when appropriate). If moved without any exceptions
+raised then the signal ``node_moved`` will be sent.
 
 .. note::
    It is assumed that when you call this method, the tree fields in the

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -10,6 +10,7 @@ from django.db.models import F, Max, Q
 from django.utils.translation import ugettext as _
 
 from mptt.exceptions import CantDisableUpdates, InvalidMove
+from mptt.signals import node_moved
 
 __all__ = ('TreeManager',)
 
@@ -443,6 +444,8 @@ class TreeManager(models.Manager):
         In most cases you should just move the node yourself by setting node.parent.
         """
         self._move_node(node, target, position=position)
+        node_moved.send(sender=node.__class__, instance=node,
+                        target=target, position=position)
 
     def root_node(self, tree_id):
         """

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -13,6 +13,7 @@ from django.utils.translation import ugettext as _
 
 from mptt.fields import TreeForeignKey, TreeOneToOneField, TreeManyToManyField
 from mptt.managers import TreeManager
+from mptt.signals import node_moved
 
 
 class _classproperty(object):
@@ -676,6 +677,8 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         In most cases you should just move the node yourself by setting node.parent.
         """
         self._tree_manager.move_node(self, target, position)
+        node_moved.send(sender=self.__class__, instance=self,
+                        target=target, position=position)
 
     def _is_saved(self, using=None):
         if not self.pk or self._mpttfield('tree_id') is None:

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -677,8 +677,6 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         In most cases you should just move the node yourself by setting node.parent.
         """
         self._tree_manager.move_node(self, target, position)
-        node_moved.send(sender=self.__class__, instance=self,
-                        target=target, position=position)
 
     def _is_saved(self, using=None):
         if not self.pk or self._mpttfield('tree_id') is None:
@@ -808,6 +806,10 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
                     # Make sure the new parent is always
                     # restored on the way out in case of errors.
                     opts.set_raw_field_value(self, opts.parent_attr, parent_id)
+
+                # If there were no exceptions raised then send a moved signal
+                node_moved.send(sender=self.__class__, instance=self,
+                                target=getattr(self, opts.parent_attr))
             else:
                 opts.set_raw_field_value(self, opts.parent_attr, parent_id)
         else:

--- a/mptt/signals.py
+++ b/mptt/signals.py
@@ -1,0 +1,10 @@
+import django.dispatch
+
+# Behaves like Djangos normal pre-/post_save signals signals with the
+# added arguments ``target`` and ``position`` that matches those of
+# ``move_to``
+node_moved = django.dispatch.Signal(providing_args=[
+    'instance',
+    'target',
+    'position'
+])

--- a/mptt/signals.py
+++ b/mptt/signals.py
@@ -2,7 +2,8 @@ import django.dispatch
 
 # Behaves like Djangos normal pre-/post_save signals signals with the
 # added arguments ``target`` and ``position`` that matches those of
-# ``move_to``
+# ``move_to``.
+# If the signal is called from ``save`` it'll not be pass position.
 node_moved = django.dispatch.Signal(providing_args=[
     'instance',
     'target',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django >= 1.4.2
+mock-django >= 0.6.5

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ setup(
     packages=[str('mptt'), str('mptt.templatetags')],
     install_requires = (
         'Django>=1.4.2',),
+    test_requires = (
+        'mock-django>=0.6.5',),
     package_data={str('mptt'): [str('templates/admin/*'), str('locale/*/*/*.*')]},
     classifiers=[
         str('Development Status :: 4 - Beta'),


### PR DESCRIPTION
The signal behaves similar to the normal Django pre-/post_save signals.

The reason for this feature is that I'm writing a system which has inherited permissions. And when I move nodes around I need to re-check if permissions on descendants needs to be reset. The other solutions I tried wasn't working satisfactory and added quite a bit complexity. So by adding this to django-mptt I made the entire solution much cleaner.

I hope you will also find this useful or at least harmless enough so I don't have to maintain a fork. :)

