### PR TITLE
Get the related field name when it doesn't use a primary key for relatio...

### DIFF
--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -426,7 +426,7 @@ class TreeManager(models.Manager):
                     'rel_table': qn(rel_model._meta.db_table),
                     'mptt_fk': qn(rel_model._meta.get_field(rel_field).column),
                     'mptt_table': qn(self.tree_model._meta.db_table),
-                    'mptt_pk': qn(meta.pk.column),
+                    'mptt_rel_to': qn(mptt_field.rel.field_name),
                     'tree_id': qn(meta.get_field(self.tree_id_attr).column),
                     'left': qn(meta.get_field(self.left_attr).column),
                     'right': qn(meta.get_field(self.right_attr).column),
@@ -436,7 +436,7 @@ class TreeManager(models.Manager):
                     'rel_table': qn(rel_model._meta.db_table),
                     'mptt_fk': qn(rel_model._meta.get_field(rel_field).column),
                     'mptt_table': qn(self.tree_model._meta.db_table),
-                    'mptt_pk': qn(meta.pk.column),
+                    'mptt_rel_to': qn(mptt_field.rel.field_name),
                 }
         return queryset.extra(select={count_attr: subquery})
 

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -16,7 +16,7 @@ __all__ = ('TreeManager',)
 COUNT_SUBQUERY = """(
     SELECT COUNT(*)
     FROM %(rel_table)s
-    WHERE %(mptt_fk)s = %(mptt_table)s.%(mptt_pk)s
+    WHERE %(mptt_fk)s = %(mptt_table)s.%(mptt_rel_to)s
 )"""
 
 CUMULATIVE_COUNT_SUBQUERY = """(
@@ -24,7 +24,7 @@ CUMULATIVE_COUNT_SUBQUERY = """(
     FROM %(rel_table)s
     WHERE %(mptt_fk)s IN
     (
-        SELECT m2.%(mptt_pk)s
+        SELECT m2.%(mptt_rel_to)s
         FROM %(mptt_table)s m2
         WHERE m2.%(tree_id)s = %(mptt_table)s.%(tree_id)s
           AND m2.%(left)s BETWEEN %(mptt_table)s.%(left)s

--- a/tests/myapp/fixtures/categories.json
+++ b/tests/myapp/fixtures/categories.json
@@ -5,6 +5,7 @@
     "fields": {
       "rght": 20,
       "name": "PC & Video Games",
+      "category_uuid": "6263ac21-f08b-4b44-9462-0489c56e0d3d",
       "parent": null,
       "level": 0,
       "lft": 1,
@@ -17,6 +18,7 @@
     "fields": {
       "rght": 7,
       "name": "Nintendo Wii",
+      "category_uuid": "c6125cec-ef08-4095-9a07-fd5c6db50cc1",
       "parent": 1,
       "level": 1,
       "lft": 2,
@@ -29,6 +31,7 @@
     "fields": {
       "rght": 4,
       "name": "Games",
+      "category_uuid": "85da870c-837a-48a5-a3e8-ab651cfdd799",
       "parent": 2,
       "level": 2,
       "lft": 3,
@@ -41,6 +44,7 @@
     "fields": {
       "rght": 6,
       "name": "Hardware & Accessories",
+      "category_uuid": "840d1ccb-9ecc-48b0-bf7c-5b0f08334d3d",
       "parent": 2,
       "level": 2,
       "lft": 5,
@@ -53,6 +57,7 @@
     "fields": {
       "rght": 13,
       "name": "Xbox 360",
+      "category_uuid": "b6299e26-d5e9-4dc2-9e2a-3f8033c8dfe5",
       "parent": 1,
       "level": 1,
       "lft": 8,
@@ -65,6 +70,7 @@
     "fields": {
       "rght": 10,
       "name": "Games",
+      "category_uuid": "8171b0ec-f6e6-46dc-aabc-46a6399d9290",
       "parent": 5,
       "level": 2,
       "lft": 9,
@@ -77,6 +83,7 @@
     "fields": {
       "rght": 12,
       "name": "Hardware & Accessories",
+      "category_uuid": "a64720cb-af69-440a-9abc-5a8f095974e4",
       "parent": 5,
       "level": 2,
       "lft": 11,
@@ -89,6 +96,7 @@
     "fields": {
       "rght": 19,
       "name": "PlayStation 3",
+      "category_uuid": "01cac717-454e-48bd-8180-8a0089613bbd",
       "parent": 1,
       "level": 1,
       "lft": 14,
@@ -101,6 +109,7 @@
     "fields": {
       "rght": 16,
       "name": "Games",
+      "category_uuid": "74f9c250-6e75-4152-bbc9-f7a89969c82b",
       "parent": 8,
       "level": 2,
       "lft": 15,
@@ -113,6 +122,7 @@
     "fields": {
       "rght": 18,
       "name": "Hardware & Accessories",
+      "category_uuid": "a4918038-4d03-48ca-8cc3-1c28e177bed5",
       "parent": 8,
       "level": 2,
       "lft": 17,

--- a/tests/myapp/fixtures/items.json
+++ b/tests/myapp/fixtures/items.json
@@ -1,0 +1,20 @@
+[
+    {
+        "pk": 1,
+        "model": "myapp.item",
+        "fields": {
+            "name": "FIFA 15",
+            "category_fk": "b6299e26-d5e9-4dc2-9e2a-3f8033c8dfe5",
+            "category_pk": 5
+        }
+    },
+    {
+        "pk": 2,
+        "model": "myapp.item",
+        "fields": {
+            "name": "Halo: Reach",
+            "category_fk": "b6299e26-d5e9-4dc2-9e2a-3f8033c8dfe5",
+            "category_pk": 5
+        }
+    }
+]

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
+import uuid
 from django.db import models
+from django.db.models.signals import pre_save
 from django.utils.encoding import python_2_unicode_compatible
 
 import mptt
@@ -26,6 +28,7 @@ class CustomTreeManager(TreeManager):
 class Category(MPTTModel):
     name = models.CharField(max_length=50)
     parent = models.ForeignKey('self', null=True, blank=True, related_name='children')
+    category_uuid = models.CharField(max_length=50, unique=True, null=True)
 
     def __str__(self):
         return self.name
@@ -33,6 +36,17 @@ class Category(MPTTModel):
     def delete(self):
         super(Category, self).delete()
     delete.alters_data = True
+
+
+@python_2_unicode_compatible
+class Item(models.Model):
+
+    name = models.CharField(max_length=100)
+    category_fk = models.ForeignKey('Category', to_field='category_uuid', null=True, related_name='items_by_fk')
+    category_pk = models.ForeignKey('Category', null=True, related_name='items_by_pk')
+
+    def __str__(self):
+        return self.name
 
 
 @python_2_unicode_compatible

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -13,6 +13,7 @@ try:
     get_models = apps.get_models
 except ImportError:  # pragma: no cover (Django 1.6 compatibility)
     from django.db.models import get_models
+from django.db.models import ManyToManyField
 from django.forms.models import modelform_factory
 from django.template import Template, TemplateSyntaxError, Context
 from django.test import TestCase
@@ -23,11 +24,12 @@ from mptt.forms import (
     MPTTAdminForm, TreeNodeChoiceField, TreeNodeMultipleChoiceField,
     MoveNodeForm)
 from mptt.models import MPTTModel
+from mptt.managers import TreeManager
 from mptt.templatetags.mptt_tags import cache_tree_children
 from mptt.utils import print_debug_info
 
 from myapp.models import (
-    Category, Genre, CustomPKName, SingleProxyModel, DoubleProxyModel,
+    Category, Item, Genre, CustomPKName, SingleProxyModel, DoubleProxyModel,
     ConcreteModel, OrderedInsertion, AutoNowDateFieldModel, Person,
     CustomTreeQueryset, Node, ReferencingModel)
 
@@ -1505,3 +1507,131 @@ class TestUnsaved(TreeTestCase):
                 ValueError,
                 'Cannot call %s on unsaved Genre instances' % method,
                 getattr(Genre(), method))
+
+class TreeManagerTestCase(TreeTestCase):
+
+    fixtures = ['categories.json', 'items.json']
+
+    def test_add_related_count_with_fk_to_natural_key(self):
+
+        # un-changed queries using pk field
+        COUNT_SUBQUERY = """(
+            SELECT COUNT(*)
+            FROM %(rel_table)s
+            WHERE %(mptt_fk)s = %(mptt_table)s.%(mptt_pk)s
+        )"""
+
+        CUMULATIVE_COUNT_SUBQUERY = """(
+            SELECT COUNT(*)
+            FROM %(rel_table)s
+            WHERE %(mptt_fk)s IN
+            (
+                SELECT m2.%(mptt_pk)s
+                FROM %(mptt_table)s m2
+                WHERE m2.%(tree_id)s = %(mptt_table)s.%(tree_id)s
+                  AND m2.%(left)s BETWEEN %(mptt_table)s.%(left)s
+                                      AND %(mptt_table)s.%(right)s
+            )
+        )"""
+
+        COUNT_SUBQUERY_M2M = """(
+            SELECT COUNT(*)
+            FROM %(rel_table)s j
+            INNER JOIN %(rel_m2m_table)s k ON j.%(rel_pk)s = k.%(rel_m2m_column)s
+            WHERE k.%(mptt_fk)s = %(mptt_table)s.%(mptt_pk)s
+        )"""
+
+        CUMULATIVE_COUNT_SUBQUERY_M2M = """(
+            SELECT COUNT(*)
+            FROM %(rel_table)s j
+            INNER JOIN %(rel_m2m_table)s k ON j.%(rel_pk)s = k.%(rel_m2m_column)s
+            WHERE k.%(mptt_fk)s IN
+            (
+                SELECT m2.%(mptt_pk)s
+                FROM %(mptt_table)s m2
+                WHERE m2.%(tree_id)s = %(mptt_table)s.%(tree_id)s
+                  AND m2.%(left)s BETWEEN %(mptt_table)s.%(left)s
+                                      AND %(mptt_table)s.%(right)s
+            )
+        )"""
+
+        class UnchangedTreeManager(TreeManager):
+
+            def add_related_count(self, queryset, rel_model, rel_field, count_attr, cumulative=False):
+                connection = self._get_connection()
+                qn = connection.ops.quote_name
+
+                meta = self.model._meta
+                mptt_field = rel_model._meta.get_field(rel_field)
+
+                if isinstance(mptt_field, ManyToManyField):
+                    if cumulative:
+                        subquery = CUMULATIVE_COUNT_SUBQUERY_M2M % {
+                            'rel_table': qn(rel_model._meta.db_table),
+                            'rel_pk': qn(rel_model._meta.pk.column),
+                            'rel_m2m_table': qn(mptt_field.m2m_db_table()),
+                            'rel_m2m_column': qn(mptt_field.m2m_column_name()),
+                            'mptt_fk': qn(mptt_field.m2m_reverse_name()),
+                            'mptt_table': qn(self.tree_model._meta.db_table),
+                            'mptt_pk': qn(meta.pk.column),
+                            'tree_id': qn(meta.get_field(self.tree_id_attr).column),
+                            'left': qn(meta.get_field(self.left_attr).column),
+                            'right': qn(meta.get_field(self.right_attr).column),
+                            }
+                    else:
+                        subquery = COUNT_SUBQUERY_M2M % {
+                            'rel_table': qn(rel_model._meta.db_table),
+                            'rel_pk': qn(rel_model._meta.pk.column),
+                            'rel_m2m_table': qn(mptt_field.m2m_db_table()),
+                            'rel_m2m_column': qn(mptt_field.m2m_column_name()),
+                            'mptt_fk': qn(mptt_field.m2m_reverse_name()),
+                            'mptt_table': qn(self.tree_model._meta.db_table),
+                            'mptt_pk': qn(meta.pk.column),
+                            }
+                else:
+                    if cumulative:
+                        subquery = CUMULATIVE_COUNT_SUBQUERY % {
+                            'rel_table': qn(rel_model._meta.db_table),
+                            'mptt_fk': qn(rel_model._meta.get_field(rel_field).column),
+                            'mptt_table': qn(self.tree_model._meta.db_table),
+                            'mptt_pk': qn(meta.pk.column),
+                            'tree_id': qn(meta.get_field(self.tree_id_attr).column),
+                            'left': qn(meta.get_field(self.left_attr).column),
+                            'right': qn(meta.get_field(self.right_attr).column),
+                            }
+                    else:
+                        subquery = COUNT_SUBQUERY % {
+                            'rel_table': qn(rel_model._meta.db_table),
+                            'mptt_fk': qn(rel_model._meta.get_field(rel_field).column),
+                            'mptt_table': qn(self.tree_model._meta.db_table),
+                            'mptt_pk': qn(meta.pk.column),
+                            }
+                return queryset.extra(select={count_attr: subquery})
+
+        # Register the un-changed manager as 'un_changed_manager'
+        manager = UnchangedTreeManager()
+        manager.contribute_to_class(Category, 'un_changed_manager')
+        manager.init_from_model(Category)
+
+        queryset = Category.objects.filter(name='Xbox 360').order_by('id')
+
+        # Un-changed manager, use the field related to Category's auto key.
+        for c in Category.un_changed_manager.add_related_count(queryset, Item, 'category_pk', 'item_count',
+                                                               cumulative=False):
+            self.assertEqual(c.item_count, c.items_by_pk.count())
+
+        # Un-changed manager, use the field related to Category's natural key.
+        for c in Category.un_changed_manager.add_related_count(queryset, Item, 'category_fk', 'item_count',
+                                                               cumulative=False):
+            # Here the item_count will be 0 since we can't get the items by the foreign key.
+            self.assertNotEqual(c.item_count, c.items_by_pk.count())
+
+        # Now we change to the modified manager and use the field related to Category's natural key.
+        for c in Category.objects.add_related_count(
+                queryset, Item, 'category_fk', 'item_count', cumulative=False):
+            self.assertEqual(c.item_count, c.items_by_pk.count())
+
+        # Also works when using the field related to Category's auto key.
+        for c in Category.objects.add_related_count(
+                queryset, Item, 'category_pk', 'item_count', cumulative=False):
+            self.assertEqual(c.item_count, c.items_by_pk.count())


### PR DESCRIPTION
add_related_count fails when the ref model is linked by a non-primary key. This patch fixes this issue.