### PR TITLE
Fix compatibility with Python 2.6.1 (Snow Leopard)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ from __future__ import unicode_literals
 
 from mptt import VERSION
 
-requires=('Django>=1.4.2',)
+requires=(str('Django>=1.4.2'),)
 try:
     from setuptools import setup
-    kwargs ={'install_requires': requires}
+    kwargs ={str('install_requires'): requires}
 except ImportError:
     from distutils.core import setup
-    kwargs = {'requires': requires}
+    kwargs = {str('requires'): requires}
 
 # Dynamically calculate the version based on mptt.VERSION
 version_tuple = VERSION


### PR DESCRIPTION
This workarounds a bug in Python 2.6.1 that has been fixed in later versions. Since this version is the default one in Snow Leopard system, it makes sense to add a simple, non-invasive workaround.
