### PR TITLE
fix recursetree. Tag was spamming database with SQL queries for child categories

### DIFF
--- a/mptt/templatetags/mptt_tags.py
+++ b/mptt/templatetags/mptt_tags.py
@@ -304,7 +304,7 @@ class RecurseTreeNode(template.Node):
     def _render_node(self, context, node):
         bits = []
         context.push()
-        for child in node.get_children():
+        for child in node._cached_children:
             bits.append(self._render_node(context, child))
         context['node'] = node
         context['children'] = mark_safe(''.join(bits))


### PR DESCRIPTION
Tag generates many SQL queries when rendering simple tree. I switched 
node.get_children() with node._cached_children ( that was already populated with children on previous step) and it fixed problem.
