### PR TITLE
Fix some of the failing python3 tests: Should use self._db as argument f...

### DIFF
--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -16,7 +16,7 @@ class CustomTreeQueryset(QuerySet):
 class CustomTreeManager(TreeManager):
     
     def get_query_set(self):
-        return CustomTreeQueryset(model=self.model, using=self.using)
+        return CustomTreeQueryset(model=self.model, using=self._db)
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
Fix some of the failing python3 tests: Should use self._db as argument for the database in use!

Sorry about the mistake there!
