### PR TITLE
Issue with ancestors when moving nodes

### DIFF
--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -156,6 +156,21 @@ class ReparentingTestCase(TreeTestCase):
             8 6 3 1 4 5
         """)
 
+    def test_moving_nested_nodes_works(self):
+        Genre.objects.all().delete()
+        g0 = Genre.objects.create(name='Zero')
+        g1 = Genre.objects.create(name='One')
+        g2 = Genre.objects.create(name='Two', parent=g1)
+        g3 = Genre.objects.create(name='Three', parent=g2)
+        g4 = Genre.objects.create(name='Four', parent=g3)
+
+        g1.parent = g0
+        g1.save()
+        g3.parent = g1
+        g3.save()
+
+        self.assertEqual(list(Genre.objects.get(id=g4.id).get_ancestors()), [g0, g1, g3])
+
     def test_new_root_from_leaf_with_siblings(self):
         platformer_2d = Genre.objects.get(id=3)
         platformer_2d.parent = None


### PR DESCRIPTION
I ran into an issue with moving nodes where the ancestors are no longer
correct. This is just a description of the error along with a failing test. I have no solution, I would be extremely grateful if someone did have a solution that they could offer. 

Consider the tree (where 1 and 0 are siblings)

```
    1          0
     \
      2
       \
        3
         \
          4
```

if I move 1 to be a direct child of 0 (giving this tree)

```
                0
                 \
                  1
                   \
                    2
                     \
                      3
                       \
                        4
```

then move 3 to be a child of 1 giving this tree

```
                 0
                  \
                   1
                  / \
                 3   2
                /
               4
```

I would expect the ancestors of 4 to now be 0, 1, 3, instead as you can
see in the failing test it is being reported as 0, 1, 2
