### PR TITLE
Fix problem with testsuite modifying migrated model auth.Group

### DIFF
--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from django.contrib.auth.models import Group
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -14,7 +13,7 @@ class CustomTreeQueryset(QuerySet):
 
 
 class CustomTreeManager(TreeManager):
-    
+
     def get_query_set(self):
         return CustomTreeQueryset(model=self.model, using=self._db)
 
@@ -191,5 +190,8 @@ class AutoNowDateFieldModel(MPTTModel):
 
 
 # test registering of remote model
+class Group(models.Model):
+    name = models.CharField(max_length=100)
+
 TreeForeignKey(Group, blank=True, null=True).contribute_to_class(Group, 'parent')
 mptt.register(Group, order_insertion_by=('name',))


### PR DESCRIPTION
Django 1.7 comes with its own migrations framework and has bundled
migrations for all models. The test which tried to run `mptt.register()`
on auth.Group always failed because Django really does not want database
changes without migrations anymore.

We can easily substitute auth.Group with our own Group model: the test
suite only checks whether saving groups works (and saving would fail if
the database would not contain MPTT's internal fields for some reason.)
