### PR TITLE
cache ancestors

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -459,28 +459,46 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
                 return self._tree_manager.none()
             else:
                 # Filter on pk for efficiency.
-                return self._tree_manager.filter(pk=self.pk)
+                qs = self._tree_manager.filter(pk=self.pk)
+        else:
+            opts = self._mptt_meta
 
-        opts = self._mptt_meta
+            order_by = opts.left_attr
+            if ascending:
+                order_by = '-' + order_by
 
-        order_by = opts.left_attr
-        if ascending:
-            order_by = '-' + order_by
+            left = getattr(self, opts.left_attr)
+            right = getattr(self, opts.right_attr)
 
-        left = getattr(self, opts.left_attr)
-        right = getattr(self, opts.right_attr)
+            if not include_self:
+                left -= 1
+                right += 1
 
-        if not include_self:
-            left -= 1
-            right += 1
+            qs = self._tree_manager._mptt_filter(
+                left__lte=left,
+                right__gte=right,
+                tree_id=self._mpttfield('tree_id'),
+            )
 
-        qs = self._tree_manager._mptt_filter(
-            left__lte=left,
-            right__gte=right,
-            tree_id=self._mpttfield('tree_id'),
-        )
+            qs = qs.order_by(order_by)
 
-        return qs.order_by(order_by)
+        if hasattr(self, '_mptt_use_cached_ancestors'):
+            # Called during or after a `recursetree` tag.
+            # There should be cached parents up to level 0.
+            # So we can use them to avoid doing a query at all.
+            ancestors = []
+            p = self
+            if not include_self:
+                p = getattr(p, opts.parent_attr)
+
+            while p is not None:
+                ancestors.append(p)
+                p = getattr(p, opts.parent_attr)
+
+            ancestors.reverse()
+            qs._result_cache = ancestors
+
+        return qs
 
     @raise_if_unsaved
     def get_family(self):

--- a/mptt/templatetags/mptt_tags.py
+++ b/mptt/templatetags/mptt_tags.py
@@ -295,6 +295,10 @@ def cache_tree_children(queryset):
                 setattr(obj, parent_attr, _parent)
                 _parent._cached_children.append(obj)
 
+                if root_level == 0:
+                    # get_ancestors() can use .parent.parent.parent...
+                    setattr(obj, '_mptt_use_cached_ancestors', True)
+
             # Add the current node to end of the current path - the last node
             # in the current path is the parent for the next iteration, unless
             # the next iteration is higher up the tree (a new branch), in which

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -1188,6 +1188,20 @@ class RecurseTreeTestCase(TreeTestCase):
             Template,
             '{% load mptt_tags %}{% recursetree %}{% endrecursetree %}')
 
+    def test_cached_ancestors(self):
+        template = Template('''
+            {% load mptt_tags %}
+            {% recursetree nodes %}
+                {{ node.get_ancestors|join:" > " }} {{ node.name }}
+                {% if not node.is_leaf_node %}
+                    {{ children }}
+                {% endif %}
+            {% endrecursetree %}
+        ''')
+        with self.assertNumQueries(1):
+            qs = Category.objects.all()
+            template.render(Context({'nodes': qs}))
+
 
 class TreeInfoTestCase(TreeTestCase):
     fixtures = ['genres.json']


### PR DESCRIPTION
In `get_ancestors`, use cached parents if all ancestors are available up to level 0.

see https://groups.google.com/d/topic/django-mptt-dev/q3nrv1RrIeY/discussion
