### PR TITLE
Modernise template tags

### DIFF
--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -21,7 +21,6 @@ try:
     get_models = apps.get_models
 except ImportError:  # pragma: no cover (Django 1.6 compatibility)
     from django.db.models import get_models
-from django.db.models import ManyToManyField
 from django.forms.models import modelform_factory
 from django.template import Template, TemplateSyntaxError, Context
 from django.test import TestCase
@@ -32,7 +31,6 @@ from mptt.forms import (
     MPTTAdminForm, TreeNodeChoiceField, TreeNodeMultipleChoiceField,
     MoveNodeForm)
 from mptt.models import MPTTModel
-from mptt.managers import TreeManager
 from mptt.templatetags.mptt_tags import cache_tree_children
 from mptt.utils import print_debug_info
 
@@ -1394,7 +1392,7 @@ class FullTreeTestCase(TreeTestCase):
     fixtures = ['genres.json']
     template = re.sub(r'(?m)^[\s]+', '', '''
         {% load mptt_tags %}
-        {% full_tree_for_model myapp.Genre as tree %}
+        {% full_tree_for_model "myapp.Genre" as tree %}
         {% for node in tree %}{{ node.pk }},{% endfor %}
         ''')
 


### PR DESCRIPTION
WIP.

Brings template tags up to date with modern stuff (`@register.assignment_tag`, etc).

Requires some backwards incompatible changes (e.g. unquoted `myapp.modelname` not supported any more, but passing actual model classes will be.)

This PR creates a deprecation path for 0.7, for backward incompatible cleanup to go into 0.8.

* [x] `full_tree_for_model`
* [ ] `drilldown_tree_for_node`
* [ ] others?