### PR TITLE
Corrected the pattern for defining get_queryset/get_query_set

### DIFF
--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -80,14 +80,6 @@ class TreeManager(_tree_manager_superclass):
                 # _base_manager is the treemanager on tree_model
                 self._base_manager = self.tree_model._tree_manager
 
-    def get_query_set(self, *args, **kwargs):
-        """
-        Ensures that this manager always returns nodes in tree order.
-
-        This method can be removed when support for Django < 1.6 is dropped.
-        """
-        return TreeQuerySet(self.model, using=self._db).order_by(self.tree_id_attr, self.left_attr)
-
     def get_queryset(self, *args, **kwargs):
         """
         Ensures that this manager always returns nodes in tree order.
@@ -97,6 +89,9 @@ class TreeManager(_tree_manager_superclass):
         else:
             qs = super(TreeManager, self).get_queryset(*args, **kwargs)
         return qs.order_by(self.tree_id_attr, self.left_attr)
+
+    if django.VERSION < (1, 6):
+        get_query_set = get_queryset
 
     def _get_queryset_relatives(self, queryset, direction, include_self):
         """


### PR DESCRIPTION
This patch makes the code follow the pattern given in the Django
1.6 release notes:

https://docs.djangoproject.com/en/1.8/releases/1.6/#get-query-set-and-similar-methods-renamed-to-get-queryset

Without this patch, you can get major errors when using Django 1.8,
as described in painful detail here:

http://lukeplant.me.uk/blog/posts/handling-django%27s-get_query_set-rename-is-hard/

... and also experienced in real situations in django-wiki (which uses django-mptt).

I could provide a test if necessary, but it would probably be more confusing than enlightening, because it involves having additional subclasses etc. I have such a test in django-wiki that currently fails on Django 1.8 due to the way django-mptt defines get_query_set, and that test passes once this patch is applied:

https://github.com/spookylukey/django-wiki/blob/django_15_fixes/wiki/tests/test_managers.py#L90

To explain, the `root.children.active()` method should clearly not return the `root` object itself, but on Django 1.8, with current django-mptt it does, due to the `RelatedManager.get_queryset` method being omitted in the call sequence.