### PR TITLE
[IMPROVE]make get_queryset_ancestors/descendants SQL querys O(1)

### DIFF
--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -131,9 +131,6 @@ class TreeManager(_tree_manager_superclass):
 
         opts = queryset.model._mptt_meta
 
-        if not queryset:
-            return self.none()
-
         filters = Q()
 
         e = 'e' if include_self else ''
@@ -150,9 +147,13 @@ class TreeManager(_tree_manager_superclass):
         min_key = '%s__%s' % (min_attr, min_op)
         max_key = '%s__%s' % (max_attr, max_op)
 
-        q = queryset.order_by(opts.tree_id_attr, opts.parent_attr, opts.left_attr)
+        q = queryset.order_by(opts.tree_id_attr, opts.parent_attr, opts.left_attr)\
+            .only(*{opts.tree_id_attr,opts.left_attr,opts.right_attr,min_attr,max_attr,opts.parent_attr})
 
-        for group in groupby(q, key = lambda n: (getattr(n, opts.tree_id_attr), getattr(n, opts.parent_attr))):
+        if not q:
+            return self.none()
+
+        for group in groupby(q, key = lambda n: (getattr(n, opts.tree_id_attr), getattr(n, opts.parent_attr+"_id"))):
             next_lft = None
             for node in list(group[1]):
                 tree, lft, rght, min_val, max_val = (getattr(node, opts.tree_id_attr),


### PR DESCRIPTION
before change, if query get n items, there will be n+2 SQL query, and each of them fetch all the fields of the query model but actually not being use at all.

After change, no matter how much items that query contains, there will be always one query and just fetch the lft,rght,and parent_id fields.