### PR TITLE
Don't import south unless it's in installed apps

### DIFF
--- a/mptt/fields.py
+++ b/mptt/fields.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 __all__ = ('TreeForeignKey', 'TreeOneToOneField', 'TreeManyToManyField')
 
 from django.db import models
+from django.conf import settings
 from mptt.forms import TreeNodeChoiceField, TreeNodeMultipleChoiceField
 
 
@@ -38,10 +39,8 @@ class TreeManyToManyField(models.ManyToManyField):
         return super(TreeManyToManyField, self).formfield(**kwargs)
 
 # South integration
-try:  # pragma: no cover
+if 'south' in settings.INSTALLED_APPS:  # pragma: no cover
     from south.modelsinspector import add_introspection_rules
     add_introspection_rules([], ["^mptt\.fields\.TreeForeignKey"])
     add_introspection_rules([], ["^mptt\.fields\.TreeOneToOneField"])
     add_introspection_rules([], ["^mptt\.fields\.TreeManyToManyField"])
-except ImportError:
-    pass


### PR DESCRIPTION
South is often included in 'install_requires' for 3rd party apps even for Django 1.7+

See https://github.com/spookylukey/django-paypal/issues/101 for an explanation as to why. 

South obviously won't be updated to support Django 1.7+ so this will cause warnings and errors if it's imported. Therefore it's much safer to check for South being in INSTALLED_APPS