### PR TITLE
Add support for working swappable models with migrations

### DIFF
--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -234,6 +234,20 @@ class DoubleProxyModel(SingleProxyModel):
         proxy = True
 
 
+# 5. swappable models
+
+class SwappableModel(MPTTModel):
+    parent = TreeForeignKey('self', null=True, blank=True, related_name='children')
+
+    class Meta:
+        swappable = 'MPTT_SWAPPABLE_MODEL'
+
+
+class SwappedInModel(MPTTModel):
+    parent = TreeForeignKey('self', null=True, blank=True, related_name='children')
+    name = models.CharField(max_length=50)
+
+
 class AutoNowDateFieldModel(MPTTModel):
     parent = TreeForeignKey('self', null=True, blank=True, related_name='children')
     now = models.DateTimeField(auto_now_add=True)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -47,3 +47,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 )
 
 ROOT_URLCONF = 'myapp.urls'
+
+# Swappable model testing
+MPTT_SWAPPABLE_MODEL = 'myapp.SwappedInModel'


### PR DESCRIPTION
Swappable models are a bit undocumented as it's a [private API](https://code.djangoproject.com/ticket/19103#comment:1), however they're currently being used for the auth app, and it's possible to use it for other apps.

This replaces some of the slightly ugly manager detection code with the _meta methods which return the managers for an object.