### PR TITLE
Use ._tree_manager in MPTT's own code instead of relying on .objects

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -60,7 +60,7 @@ class MPTTModelAdmin(ModelAdmin):
         # If this is True, the confirmation page has been displayed
         if request.POST.get('post'):
             n = 0
-            with queryset.model.objects.delay_mptt_updates():
+            with queryset.model._tree_manager.delay_mptt_updates():
                 for obj in queryset:
                     if self.has_delete_permission(request, obj):
                         obj.delete()

--- a/mptt/querysets.py
+++ b/mptt/querysets.py
@@ -8,14 +8,14 @@ class TreeQuerySet(models.query.QuerySet):
         """
         Alias to `mptt.managers.TreeManager.get_queryset_descendants`.
         """
-        return self.model.objects.get_queryset_descendants(self, *args, **kwargs)
+        return self.model._tree_manager.get_queryset_descendants(self, *args, **kwargs)
     get_descendants.queryset_only = True
 
     def get_ancestors(self, *args, **kwargs):
         """
         Alias to `mptt.managers.TreeManager.get_queryset_ancestors`.
         """
-        return self.model.objects.get_queryset_ancestors(self, *args, **kwargs)
+        return self.model._tree_manager.get_queryset_ancestors(self, *args, **kwargs)
     get_ancestors.queryset_only = True
 
     def get_cached_trees(self):


### PR DESCRIPTION
I'm a bit surprised that `_tree_manager` isn't mentioned anywhere in the documentation. 

I know (and wholeheartedly approve) about #107 / https://github.com/django-mptt/django-mptt/commit/1651bf75d75af8c17a89bfd02754e4d85f84e658, but I'm still somewhat unsure what the "official way" to access the tree manager would be. Or should be always use `_default_manager` as is already the case in some parts of django-mptt's code?