### PR TITLE
MANIFEST.in: Exclude pyc files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,4 @@ recursive-include tests *
 recursive-include mptt/templates *
 recursive-include mptt/locale *
 recursive-include mptt/static *
+global-exclude __pycache__ *.pyc


### PR DESCRIPTION
Exclude *.pyc files from sdist, since they don't belong to source
distributions.

Fixes GitHub issue #450.