### PR TITLE
Add django master in TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
       python: "3.2"
     - env: DJANGO="Django>=1.9,<1.10"
       python: "3.3"
+    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+      python: "3.2"
+    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+      python: "3.3"
   allow_failures:
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+
 python:
   - "3.5"
   - "3.4"
@@ -7,9 +8,12 @@ python:
   - "3.2"
   - "2.7"
   - "pypy"
+
 env:
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
+  - DJANGO="https://github.com/django/django/archive/master.tar.gz"
+
 matrix:
   exclude:
     - env: DJANGO="Django>=1.8,<1.9"
@@ -18,11 +22,10 @@ matrix:
       python: "3.2"
     - env: DJANGO="Django>=1.9,<1.10"
       python: "3.3"
+  allow_failures:
+    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install $DJANGO mock-django==0.6.9
 # command to run tests, e.g. python setup.py test
 script: cd tests/ && ./runtests.sh
-
-# Run on travis' container infrastructure
-sudo: false


### PR DESCRIPTION
Hello,

I am suggest add tests over django master to fast feedback what can be broken in future django releases. It is failurable tests, so provide feedback, but isn't misleading for developer which create a pull requests. It doesn't affect GitHub pull requests status.

I drop duplicated ```sudo: false``` too.

Greetings,