### PR TITLE
Fix TreeManager._move_child_within_tree breaks with UUIDField() as primary key.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 MANIFEST
 tests/mydatabase
 *.egg
+.eggs

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -73,6 +73,7 @@ def delegate_manager(method):
 
 
 class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
+
     """
     A manager for working with trees of objects.
     """
@@ -1164,7 +1165,8 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             left_boundary, right_boundary, gap_size,
             left, right, left_right_change,
             left_boundary, right_boundary, gap_size,
-            node.pk, parent.pk,
+            node._meta.get_field(node._meta.pk.name).get_db_prep_value(node.pk, connection),
+            parent._meta.get_field(parent._meta.pk.name).get_db_prep_value(parent.pk, connection),
             tree_id])
 
         # Update the node to be consistent with the updated

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -843,7 +843,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             gap_target_left, gap_size,
             left, right, left_right_change,
             gap_target_left, gap_size,
-            node.pk,
+            node._meta.pk.get_db_prep_value(node.pk, connection),
             getattr(node, self.tree_id_attr)
         ]
         if parent_pk is not None:
@@ -1036,8 +1036,10 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         # Make space for the subtree which will be moved
         self._create_space(tree_width, space_target, new_tree_id)
         # Move the subtree
+        connection = self._get_connection(instance=node)
         self._inter_tree_move_and_close_gap(
-            node, level_change, left_right_change, new_tree_id, parent.pk)
+            node, level_change, left_right_change, new_tree_id,
+            parent._meta.pk.get_db_prep_value(parent.pk, connection))
 
         # Update the node to be consistent with the updated
         # tree in the database.
@@ -1233,7 +1235,10 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         cursor = connection.cursor()
         cursor.execute(move_tree_query, [
             level_change, left_right_change, left_right_change,
-            new_tree_id, node.pk, parent.pk, left, right, tree_id])
+            new_tree_id,
+            node._meta.pk.get_db_prep_value(node.pk, connection),
+            parent._meta.pk.get_db_prep_value(parent.pk, connection),
+            left, right, tree_id])
 
         # Update the former root node to be consistent with the updated
         # tree in the database.

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from django.db import models
 from django.utils.encoding import python_2_unicode_compatible
+from uuid import uuid4
 
 import mptt
 from mptt.fields import TreeForeignKey, TreeOneToOneField, TreeManyToManyField
@@ -10,11 +11,13 @@ from django.db.models.query import QuerySet
 
 
 class CustomTreeQueryset(QuerySet):
+
     def custom_method(self):
         pass
 
 
 class CustomTreeManager(TreeManager):
+
     def get_query_set(self):
         return CustomTreeQueryset(model=self.model, using=self._db)
 
@@ -111,6 +114,15 @@ class Node(MPTTModel):
         right_attr = 'zis'
         level_attr = 'level'
         tree_id_attr = 'work'
+
+
+class UUIDNode(MPTTModel):
+    parent = models.ForeignKey('self', null=True, blank=True, related_name='children')
+    uuid = models.UUIDField(primary_key=True, default=uuid4)
+    name = models.CharField(max_length=50)
+
+    def __str__(self):
+        return self.name
 
 
 @python_2_unicode_compatible
@@ -226,6 +238,7 @@ class ConcreteModel(AbstractModel):
 
 class AbstractConcreteAbstract(ConcreteModel):
     # abstract --> concrete --> abstract
+
     class Meta:
         abstract = True
 
@@ -250,6 +263,7 @@ class SingleProxyModel(ConcreteModel):
 
 
 class DoubleProxyModel(SingleProxyModel):
+
     class Meta:
         proxy = True
 

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -2316,3 +2316,24 @@ class UUIDPrimaryKey(TreeTestCase):
         n3.move_to(n2, 'left')
 
         self.assertEqual(list(n1.get_children()), [n3, n2])
+
+    def test_move_root_node(self):
+        root1 = UUIDNode.objects.create(name='n1')
+        child = UUIDNode.objects.create(name='n2', parent=root1)
+        root2 = UUIDNode.objects.create(name='n3')
+        self.assertEqual(list(root1.get_children()), [child])
+
+        root2.move_to(child, 'left')
+
+        self.assertEqual(list(root1.get_children()), [root2, child])
+
+    def test_move_child_node(self):
+        root1 = UUIDNode.objects.create(name='n1')
+        child1 = UUIDNode.objects.create(name='n2', parent=root1)
+        root2 = UUIDNode.objects.create(name='n3')
+        child2 = UUIDNode.objects.create(name='n4', parent=root2)
+        self.assertEqual(list(root1.get_children()), [child1])
+
+        child2.move_to(child1, 'left')
+
+        self.assertEqual(list(root1.get_children()), [child2, child1])

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -6,6 +6,7 @@ import re
 import sys
 import tempfile
 import unittest
+import uuid
 
 from django import forms
 from django.contrib.auth.models import Group, User
@@ -15,7 +16,8 @@ from django.apps import apps
 from django.forms.models import modelform_factory
 from django.template import Template, TemplateSyntaxError, Context
 from django.test import RequestFactory, TestCase
-from django.utils.six import string_types, PY3, b, assertRaisesRegex
+from django.utils.six import (
+    string_types, PY3, b, assertRaisesRegex, integer_types)
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.admin import ModelAdmin, site
 from mptt.admin import TreeRelatedFieldListFilter
@@ -39,7 +41,8 @@ from mptt.utils import print_debug_info
 from myapp.models import (
     Category, Item, Genre, CustomPKName, SingleProxyModel, DoubleProxyModel,
     ConcreteModel, OrderedInsertion, AutoNowDateFieldModel, Person,
-    CustomTreeQueryset, Node, ReferencingModel, CustomTreeManager, Book)
+    CustomTreeQueryset, Node, ReferencingModel, CustomTreeManager, Book,
+    UUIDNode)
 
 
 def get_tree_details(nodes):
@@ -72,6 +75,7 @@ def tree_details(text):
 
 
 class TreeTestCase(TestCase):
+
     def assertTreeEqual(self, tree1, tree2):
         if not isinstance(tree1, string_types):
             tree1 = get_tree_details(tree1)
@@ -83,6 +87,7 @@ class TreeTestCase(TestCase):
 
 
 class DocTestTestCase(TreeTestCase):
+
     def test_run_doctest(self):
         class DummyStream:
             content = ""
@@ -142,6 +147,7 @@ class DocTestTestCase(TreeTestCase):
 
 
 class ReparentingTestCase(TreeTestCase):
+
     """
     Test that trees are in the appropriate state after reparenting and
     that reparented items have the correct tree attributes defined,
@@ -321,10 +327,12 @@ class ReparentingTestCase(TreeTestCase):
 
 
 class ConcurrencyTestCase(TreeTestCase):
+
     """
     Test that tree structure remains intact when saving nodes (without setting new parent) after
     tree structure has been changed.
     """
+
     def setUp(self):
         fruit = ConcreteModel.objects.create(name="Fruit")
         vegie = ConcreteModel.objects.create(name="Vegie")
@@ -427,6 +435,7 @@ class ConcurrencyTestCase(TreeTestCase):
 
 
 class DeletionTestCase(TreeTestCase):
+
     """
     Tests that the tree structure is maintained appropriately in various
     deletion scenarios.
@@ -539,6 +548,7 @@ class PositionedInsertionTestCase(TreeTestCase):
 
 
 class CustomPKNameTestCase(TreeTestCase):
+
     def setUp(self):
         manager = CustomPKName.objects
         c1 = manager.create(name="c1")
@@ -558,6 +568,7 @@ class CustomPKNameTestCase(TreeTestCase):
 
 
 class DisabledUpdatesTestCase(TreeTestCase):
+
     def setUp(self):
         self.a = ConcreteModel.objects.create(name="a")
         self.b = ConcreteModel.objects.create(name="b", parent=self.a)
@@ -748,6 +759,7 @@ class DisabledUpdatesTestCase(TreeTestCase):
 
 
 class DelayedUpdatesTestCase(TreeTestCase):
+
     def setUp(self):
         self.a = ConcreteModel.objects.create(name="a")
         self.b = ConcreteModel.objects.create(name="b", parent=self.a)
@@ -952,6 +964,7 @@ class DelayedUpdatesTestCase(TreeTestCase):
 
 
 class OrderedInsertionDelayedUpdatesTestCase(TreeTestCase):
+
     def setUp(self):
         self.c = OrderedInsertion.objects.create(name="c")
         self.d = OrderedInsertion.objects.create(name="d", parent=self.c)
@@ -1283,6 +1296,7 @@ class ManagerTests(TreeTestCase):
 
 
 class CacheTreeChildrenTestCase(TreeTestCase):
+
     """
     Tests for the ``cache_tree_children`` template filter.
     """
@@ -1323,6 +1337,7 @@ class CacheTreeChildrenTestCase(TreeTestCase):
 
 
 class RecurseTreeTestCase(TreeTestCase):
+
     """
     Tests for the ``recursetree`` template filter.
     """
@@ -1521,6 +1536,7 @@ class TestAutoNowDateFieldModel(TreeTestCase):
 
 
 class RegisteredRemoteModel(TreeTestCase):
+
     def test_save_registered_model(self):
         g1 = Group.objects.create(name='group 1')
         g1.save()
@@ -1603,6 +1619,7 @@ class TestForms(TreeTestCase):
 
 
 class TestAltersData(TreeTestCase):
+
     def test_alters_data(self):
         node = Node()
         output = Template('{{ node.save }}').render(Context({
@@ -1679,6 +1696,7 @@ class AdminBatch(TreeTestCase):
 
 
 class TestUnsaved(TreeTestCase):
+
     def test_unsaved(self):
         for method in [
             'get_ancestors',
@@ -1758,6 +1776,7 @@ class TreeManagerTestCase(TreeTestCase):
 
 
 class TestOrderedInsertionBFS(TreeTestCase):
+
     def test_insert_ordered_DFS_backwards_root_nodes(self):
         rock = OrderedInsertion.objects.create(name="Rock")
 
@@ -1832,6 +1851,7 @@ class TestOrderedInsertionBFS(TreeTestCase):
 
 
 class CacheChildrenTestCase(TreeTestCase):
+
     """
     Tests that the queryset function `get_cached_trees` results in a minimum
     number of database queries.
@@ -1910,9 +1930,11 @@ class Signals(TestCase):
 
 
 class DeferredAttributeTests(TreeTestCase):
+
     """
     Regression tests for #176 and #424
     """
+
     def setUp(self):
         OrderedInsertion.objects.create(name="a")
 
@@ -1952,6 +1974,7 @@ class DeferredAttributeTests(TreeTestCase):
 
 
 class DraggableMPTTAdminTestCase(TreeTestCase):
+
     def setUp(self):
         self.user = User.objects.create_superuser(
             'admin', 'test@example.com', 'p')
@@ -2273,3 +2296,23 @@ class ListFiltersTests(TestCase):
         changelist = self.get_changelist(request, Category, modeladmin)
         queryset = changelist.get_queryset(request)
         self.assertEqual(queryset.count(), 0)
+
+
+class UUIDPrimaryKey(TreeTestCase):
+
+    def test_save_uuid_model(self):
+        n1 = UUIDNode.objects.create(name='node')
+        n2 = UUIDNode.objects.create(name='sub_node', parent=n1)
+        self.assertEqual(n1.name, 'node')
+        self.assertEqual(n1.tree_id, n2.tree_id)
+        self.assertEqual(n2.parent, n1)
+
+    def test_move_uuid_node(self):
+        n1 = UUIDNode.objects.create(name='n1')
+        n2 = UUIDNode.objects.create(name='n2', parent=n1)
+        n3 = UUIDNode.objects.create(name='n3', parent=n1)
+        self.assertEqual(list(n1.get_children()), [n2, n3])
+
+        n3.move_to(n2, 'left')
+
+        self.assertEqual(list(n1.get_children()), [n3, n2])


### PR DESCRIPTION
Thanks for #357 and #322.