### PR TITLE
Add an 'all' argument to drilldown_tree_for_node.

### DIFF
--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -96,8 +96,8 @@ Populates a template variable with the drilldown tree for a given node,
 optionally counting the number of items associated with its children.
 
 A drilldown tree consists of a node's ancestors, itself and its
-immediate children. For example, a drilldown tree for a book category
-"Personal Finance" might look something like::
+immediate children or all descendants. For example, a drilldown tree
+for a book category "Personal Finance" might look something like::
 
    Books
       Business, Finance & Law
@@ -111,6 +111,7 @@ Usage::
 
 Extended usage::
 
+   {% drilldown_tree_for_node [node] as [varname] all_descendants %}
    {% drilldown_tree_for_node [node] as [varname] count [foreign_key] in [count_attr] %}
    {% drilldown_tree_for_node [node] as [varname] cumulative count [foreign_key] in [count_attr] %}
 

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -62,7 +62,7 @@ It creates an iterable which yields model instances representing a
 drilldown tree for a given node.
 
 A drilldown tree consists of a node's ancestors, itself and its
-immediate children, all in tree order.
+immediate children or all descendants, all in tree order.
 
 Optional arguments may be given to specify details of a relationship
 between the given node's class and another model class, for the

--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -118,11 +118,11 @@ def tree_item_iterator(items, ancestors=False, callback=str):
 
 
 def drilldown_tree_for_node(node, rel_cls=None, rel_field=None, count_attr=None,
-                            cumulative=False):
+                            cumulative=False, all_descendants=False):
     """
     Creates a drilldown tree for the given node. A drilldown tree
-    consists of a node's ancestors, itself and its immediate children,
-    all in tree order.
+    consists of a node's ancestors, itself and its immediate children
+    or all descendants, all in tree order.
 
     Optional arguments may be given to specify a ``Model`` class which
     is related to the node's class, for the purpose of adding related
@@ -143,12 +143,17 @@ def drilldown_tree_for_node(node, rel_cls=None, rel_field=None, count_attr=None,
     ``cumulative``
        If ``True``, the count will be for each child and all of its
        descendants, otherwise it will be for each child itself.
+
+    ``all_descendants``
+       If ``True``, return all descendants, not just immediate children.
     """
-    if rel_cls and rel_field and count_attr:
-        children = node._tree_manager.add_related_count(
-            node.get_children(), rel_cls, rel_field, count_attr, cumulative)
+    if all_descendants:
+        children = node.get_descendants()
     else:
         children = node.get_children()
+    if rel_cls and rel_field and count_attr:
+        children = node._tree_manager.add_related_count(
+            children, rel_cls, rel_field, count_attr, cumulative)
     return itertools.chain(node.get_ancestors(), [node], children)
 
 

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -1518,8 +1518,10 @@ class DrilldownTreeTestCase(TreeTestCase):
         {% endfor %}
         ''')
 
-    def render_for_node(self, pk, cumulative=False, m2m=False):
+    def render_for_node(self, pk, cumulative=False, m2m=False, all_descendants=False):
         template = self.template
+        if all_descendants:
+            template = template.replace(' count myapp.Game.genre in game_count ', ' all_descendants ')
         if cumulative:
             template = template.replace(' count ', ' cumulative count ')
         if m2m:
@@ -1562,6 +1564,13 @@ class DrilldownTreeTestCase(TreeTestCase):
         self.assertEqual(
             self.render_for_node(2, cumulative=True, m2m=True),
             '1:,[2:],3:2,4:3,5:4')
+
+        self.assertEqual(
+            self.render_for_node(1, all_descendants=True),
+            '[1:],2:,3:,4:,5:,6:,7:,8:')
+        self.assertEqual(
+            self.render_for_node(2, all_descendants=True),
+            '1:,[2:],3:,4:,5:')
 
 
 class TestAutoNowDateFieldModel(TreeTestCase):


### PR DESCRIPTION
This adds a new optional argument (immediately after the required
arguments) to have the function return all descendants of the node,
not just its immediate children.

I added this because I wanted the cumulative count functionality of drilldown_tree_for_node, but wanted to show all the descendants of a particular node, not just its children. I'm not sure if there's a different/better way I could have done this, feel free to let me know :)

Rebased version of #246
