### PR TITLE
Keep the state of nodes when opening new tabs

### DIFF
--- a/mptt/static/mptt/draggable-admin.js
+++ b/mptt/static/mptt/draggable-admin.js
@@ -268,7 +268,7 @@ django.jQuery(function($){
     /* Every time the user expands or collapses a part of the tree, we remember
        the current state of the tree so we can restore it on a reload. */
     function storeCollapsedNodes(nodes) {
-        window.sessionStorage && window.sessionStorage.setItem(
+        window.localStorage && window.localStorage.setItem(
             DraggableMPTTAdmin.storageName,
             JSON.stringify(nodes)
         );
@@ -276,7 +276,7 @@ django.jQuery(function($){
 
     function retrieveCollapsedNodes() {
         try {
-            return JSON.parse(window.sessionStorage.getItem(
+            return JSON.parse(window.localStorage.getItem(
                 DraggableMPTTAdmin.storageName
             ));
         } catch(e) {


### PR DESCRIPTION
FeinCMS' TreeEditor saved the state of nodes in a cookie (which also preserved state across tabs). 