### PR TITLE
Reverting update in commit b0c8561876 due to an issue

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -394,7 +394,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
     def __init__(self, *args, **kwargs):
         super(MPTTModel, self).__init__(*args, **kwargs)
         self._mptt_meta.update_mptt_cached_fields(self)
-        self._tree_manager = self._tree_manager.db_manager(self._state.db)
+    #    self._tree_manager = self._tree_manager.db_manager(self._state.db)
 
     def _mpttfield(self, fieldname):
         translated_fieldname = getattr(self._mptt_meta, fieldname + '_attr')


### PR DESCRIPTION
Issue is related with package django-modeltranslation.

If this line is active, then error is shown: AttributeError: Can't pickle local object 'add_manager.<locals>.patch_manager_class.<locals>.NewMultilingualManager'.

https://github.com/deschler/django-modeltranslation/blob/master/modeltranslation/translator.py#L188

I'm not sure - why is this line needed?