### PR TITLE
Support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
 env:
   - DJANGO="Django>=1.8,<1.9"
   - DJANGO="Django>=1.9,<1.10"
+  - DJANGO="Django>=1.10,<1.11"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 
 matrix:
@@ -21,6 +22,10 @@ matrix:
     - env: DJANGO="Django>=1.9,<1.10"
       python: "3.2"
     - env: DJANGO="Django>=1.9,<1.10"
+      python: "3.3"
+    - env: DJANGO="Django>=1.10,<1.11"
+      python: "3.2"
+    - env: DJANGO="Django>=1.10,<1.11"
       python: "3.3"
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
       python: "3.2"

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -335,15 +335,6 @@ class MPTTModelBase(ModelBase):
 
             # Add a tree manager, if there isn't one already
             if not abstract:
-                manager = getattr(cls, 'objects', None)
-                if manager is None:
-                    manager = cls._default_manager._copy_to_model(cls)
-                    manager.contribute_to_class(cls, 'objects')
-                elif manager.model != cls:
-                    # manager was inherited
-                    manager = manager._copy_to_model(cls)
-                    manager.contribute_to_class(cls, 'objects')
-
                 # make sure we have a tree manager somewhere
                 tree_manager = None
                 if hasattr(cls._meta, 'concrete_managers'):  # Django < 1.10
@@ -386,10 +377,11 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
     """
     Base class for tree models.
     """
-    _default_manager = TreeManager()
 
     class Meta:
         abstract = True
+
+    objects = TreeManager()
 
     def __init__(self, *args, **kwargs):
         super(MPTTModel, self).__init__(*args, **kwargs)

--- a/tests/myapp/doctests.txt
+++ b/tests/myapp/doctests.txt
@@ -207,25 +207,6 @@
 </select>
 
 # TreeManager Methods #########################################################
-# check that tree manager is the explicitly defined tree manager for Person
->>> Person._tree_manager == Person.objects
-True
-
-# managers of non-abstract bases don't get inherited, so:
->>> Student._tree_manager == Student.objects
-False
-
->>> Student._tree_manager == Person._tree_manager
-False
-
->>> Student._tree_manager.model
-<class 'myapp.models.Student'>
->>> Student._tree_manager.tree_model
-<class 'myapp.models.Person'>
->>> Person._tree_manager.model
-<class 'myapp.models.Person'>
->>> Person._tree_manager.tree_model
-<class 'myapp.models.Person'>
 
 >>> Genre.objects.root_node(action.tree_id)
 <Genre: Action>

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -164,9 +164,6 @@ class Person(MPTTModel):
     # just testing it's actually possible to override the tree manager
     objects = CustomTreeManager()
 
-    # This line is set because of https://github.com/django-mptt/django-mptt/issues/369
-    _default_manager = objects
-
     def __str__(self):
         return self.name
 

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -40,7 +40,7 @@ from myapp.models import (
     Category, Item, Genre, CustomPKName, SingleProxyModel, DoubleProxyModel,
     ConcreteModel, OrderedInsertion, AutoNowDateFieldModel, Person,
     CustomTreeQueryset, Node, ReferencingModel, CustomTreeManager, Book,
-    UUIDNode)
+    UUIDNode, Student)
 
 
 def get_tree_details(nodes):
@@ -1158,6 +1158,13 @@ class ManagerTests(TreeTestCase):
                     "Tree managers for %s and %s are the same manager"
                     % (model.__name__, seen[id(tm)].__name__))
             seen[id(tm)] = model
+
+    def test_manager_multi_table_inheritance(self):
+        self.assertIs(Student._tree_manager.model, Student)
+        self.assertIs(Student._tree_manager.tree_model, Person)
+
+        self.assertIs(Person._tree_manager.model, Person)
+        self.assertIs(Person._tree_manager.tree_model, Person)
 
     def test_all_managers_have_correct_model(self):
         # all tree managers should have the correct model.

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
-envlist = 
+envlist =
     {py27,py32,py33,py34,pypy}-{dj18}
-    {py27,py34,py35,pypy}-{dj19}
+    {py27,py34,py35,pypy}-{dj19,dj110}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -16,4 +16,5 @@ basepython =
 deps =
     mock_django>=0.6.7
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9
+    dj19: Django>=1.9,<1.10
+    dj110: Django>=1.10,<1.11


### PR DESCRIPTION
fixes #469

This removes a bunch of legacy manager stuff which was stuffing up the new way that django assigns default managers.

Now we always supply an `objects` manager. I had a feeling that this was a backwards-incompatible change but I can't put my finger on why. It seems that:

 * with django<1.10, `objects` would have been supplied by default anyway, and if subclasses supply their own manager then they can use that instead, but us adding `objects` won't break them
 * with django>=1.10, if subclasses provide an alternate `default_manager_name` then the _default_ manager may not be a `TreeManager`. But `objects` still will be.

If subclasses override `objects` with their own manager, we still provide `_tree_manager` to ensure there's a `TreeManager` somewhere.

Some of this will change again in 1.0 with the nomagic merge, but I think this is a good interim solution. I'd like to release for 0.8.6 but am aware there might be backwards incompatibilities I haven't considered. Thoughts @matthiask ?