### PR TITLE
Reset root level for each new tree when caching children. Fix #420

### DIFF
--- a/mptt/templatetags/mptt_tags.py
+++ b/mptt/templatetags/mptt_tags.py
@@ -232,10 +232,16 @@ def tree_path(items, separator=' :: '):
 @register.filter
 def cache_tree_children(queryset):
     """
-    Alias to `mptt.utils.get_cached_trees`.
+    Alias to `mptt.utils.get_cached_trees`, suppressing errors for filtered
+    querysets to avoid 500 errors being thrown when using the django admin
+    search, and preserving previous behaviour as much as possible.
     """
 
-    return get_cached_trees(queryset)
+    allow_filtered = False
+    if hasattr(queryset, 'query') and hasattr(queryset.query, 'has_filters'):
+        allow_filtered = queryset.query.has_filters()
+
+    return get_cached_trees(queryset, allow_filtered=allow_filtered)
 
 
 class RecurseTreeNode(template.Node):

--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -225,13 +225,17 @@ def get_cached_trees(queryset):
         # Get the model's parent-attribute name
         parent_attr = queryset[0]._mptt_meta.parent_attr
         root_level = None
+        current_tree_id = None
         for obj in queryset:
-            # Get the current mptt node level
+            # Get the current mptt node level and tree_id
             node_level = obj.get_level()
+            node_tree_id = getattr(obj, obj._mptt_meta.tree_id_attr)
 
-            if root_level is None:
-                # First iteration, so set the root level to the top node level
+            if node_tree_id != current_tree_id or root_level is None:
+                # First iteration or first node of a new tree, so set the root
+                # level to the top node level
                 root_level = node_level
+                current_tree_id = node_tree_id
 
             if node_level < root_level:
                 # ``queryset`` was a list or other iterable (unable to order),


### PR DESCRIPTION
This avoids ValueErrors being thrown with filtered querysets, such as
when displaying search results in an admin changelist view.
