### PR TITLE
reverse order issue fixed

### DIFF
--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -164,7 +164,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             max_attr,
             opts.parent_attr,
             # These fields are used by MPTTModel.update_mptt_cached_fields()
-            *opts.order_insertion_by
+            *[f.lstrip('-') for f in opts.order_insertion_by],
         )
 
         if not q:

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -164,7 +164,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             max_attr,
             opts.parent_attr,
             # These fields are used by MPTTModel.update_mptt_cached_fields()
-            *[f.lstrip('-') for f in opts.order_insertion_by],
+            *[f.lstrip('-') for f in opts.order_insertion_by]
         )
 
         if not q:


### PR DESCRIPTION
queryset.only() throws exception if called with '-field' instead of 'field', so it's impossible to use get_descendants if one of the order_insertion_by fields uses reverse order
lstrip('-') for each order_insertion_by field before calling that function helps to fix that issue

how to check the problem: create MPTTModel with priority = models.IntegerField() and order_insertion_by = ['-priority'], call Model.objects.get_descendants()