### PR TITLE
FIX #517: TreeManager get_queryset_descendants and get_queryset_ancestors

### DIFF
--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -148,11 +148,14 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         if direction == 'asc':
             max_attr = opts.left_attr
             min_attr = opts.right_attr
+            level_dir = max_op
         elif direction == 'desc':
             max_attr = opts.right_attr
             min_attr = opts.left_attr
+            level_dir = min_op
 
         tree_key = opts.tree_id_attr
+        level_key = '%s__%s' % (opts.level_attr, level_dir)
         min_key = '%s__%s' % (min_attr, min_op)
         max_key = '%s__%s' % (max_attr, max_op)
 
@@ -163,6 +166,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             min_attr,
             max_attr,
             opts.parent_attr,
+            opts.level_attr,
             # These fields are used by MPTTModel.update_mptt_cached_fields()
             *[f.lstrip('-') for f in opts.order_insertion_by]
         )
@@ -178,30 +182,35 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                 )):
             next_lft = None
             for node in list(group[1]):
-                tree, lft, rght, min_val, max_val = (getattr(node, opts.tree_id_attr),
+                tree, lft, rght, min_val, max_val, level = (getattr(node, opts.tree_id_attr),
                                                      getattr(node, opts.left_attr),
                                                      getattr(node, opts.right_attr),
                                                      getattr(node, min_attr),
-                                                     getattr(node, max_attr))
+                                                     getattr(node, max_attr),
+                                                     getattr(node, opts.level_attr))
                 if next_lft is None:
                     next_lft = rght + 1
-                    min_max = {'min': min_val, 'max': max_val}
+                    min_max = {'min': min_val, 'max': max_val, 'level': level}
                 elif lft == next_lft:
                     if min_val < min_max['min']:
                         min_max['min'] = min_val
                     if max_val > min_max['max']:
                         min_max['max'] = max_val
+                    if level < min_max['level']:
+                        min_max['level'] = level
                     next_lft = rght + 1
                 elif lft != next_lft:
                     filters |= Q(**{
                         tree_key: tree,
+                        level_key: min_max['level'],
                         min_key: min_max['min'],
                         max_key: min_max['max'],
                     })
-                    min_max = {'min': min_val, 'max': max_val}
+                    min_max = {'min': min_val, 'max': max_val, 'level': level}
                     next_lft = rght + 1
             filters |= Q(**{
                 tree_key: tree,
+                level_key: min_max['level'],
                 min_key: min_max['min'],
                 max_key: min_max['max'],
             })

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -1299,6 +1299,27 @@ class ManagerTests(TreeTestCase):
                 Category.objects.all(), include_self=True)
             self.assertEqual(len(qs), 10)
 
+    def test_get_queryset_descendants_include_self(self):
+        """Fails when siblings>=3 and sibling_level=1."""
+        siblings = 3
+        sibling_level = 1
+
+        parent = Node.objects.create(level=0)
+        for i in range(1, sibling_level):
+            parent = Node.objects.create(level=i)
+        for i in range(siblings):
+            level_node = Node.objects.create(parent=parent)
+            Node.objects.create(parent=level_node)
+
+        level_qs = Node.objects.filter(level=sibling_level)
+        manager_qs = list(Node.objects.get_queryset_descendants(level_qs, include_self=False))
+
+        per_node = []
+        for node in level_qs:
+            per_node.extend(node.get_descendants(include_self=False))
+
+        self.assertItemsEqual(manager_qs, per_node)
+
 
 class CacheTreeChildrenTestCase(TreeTestCase):
 

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -1318,7 +1318,7 @@ class ManagerTests(TreeTestCase):
         for node in level_qs:
             per_node.extend(node.get_descendants(include_self=False))
 
-        self.assertItemsEqual(manager_qs, per_node)
+        self.assertListEqual(manager_qs, per_node)
 
 
 class CacheTreeChildrenTestCase(TreeTestCase):


### PR DESCRIPTION
Needed to take into account the lowest or highest level of a sibling when constructing the query for ancestors or descendants respectively. All unit tests are passing and added a new test as reported by  @thecardcheat
