### PR TITLE
Use ModelSignal over plain Signal

### DIFF
--- a/mptt/signals.py
+++ b/mptt/signals.py
@@ -1,10 +1,10 @@
-import django.dispatch
+from django.db.models.signals import ModelSignal as Signal
 
 # Behaves like Djangos normal pre-/post_save signals signals with the
 # added arguments ``target`` and ``position`` that matches those of
 # ``move_to``.
 # If the signal is called from ``save`` it'll not be pass position.
-node_moved = django.dispatch.Signal(providing_args=[
+node_moved = Signal(providing_args=[
     'instance',
     'target',
     'position'

--- a/mptt/signals.py
+++ b/mptt/signals.py
@@ -1,10 +1,10 @@
-from django.db.models.signals import ModelSignal as Signal
+from django.db.models.signals import ModelSignal
 
 # Behaves like Djangos normal pre-/post_save signals signals with the
 # added arguments ``target`` and ``position`` that matches those of
 # ``move_to``.
 # If the signal is called from ``save`` it'll not be pass position.
-node_moved = Signal(providing_args=[
+node_moved = ModelSignal(providing_args=[
     'instance',
     'target',
     'position'

--- a/mptt/signals.py
+++ b/mptt/signals.py
@@ -4,6 +4,7 @@ from django.db.models.signals import ModelSignal
 # added arguments ``target`` and ``position`` that matches those of
 # ``move_to``.
 # If the signal is called from ``save`` it'll not be pass position.
+
 node_moved = ModelSignal(providing_args=[
     'instance',
     'target',


### PR DESCRIPTION
ModelSignal lets you specify the sender as a dotted string (i.e `app_label.ModelName`) which really helps with circular import weirdness.

Edit: It appears pypy builds are failing randomly. Any ideas?