### PR TITLE
Add failing test to expose root node edge case

### DIFF
--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -1782,6 +1782,14 @@ class TreeManagerTestCase(TreeTestCase):
 
 class TestOrderedInsertionBFS(TreeTestCase):
 
+    def test_back_and_forth_updates(self):
+        b = OrderedInsertion.objects.create(name="b")
+        a = OrderedInsertion.objects.create(name="a")
+        b.name = "bb"
+        b.save()
+        b.name = "ba"
+        b.save()
+
     def test_insert_ordered_DFS_backwards_root_nodes(self):
         rock = OrderedInsertion.objects.create(name="Rock")
 


### PR DESCRIPTION
I encountered this same error in a real app after enabling `order_insertion_by`.  It's not clear to me how to fix, but I was able to reproduce in a test case.  The problem seems to be in this code:
```python
right_sibling = target.get_next_sibling()
if node == right_sibling:
    return
new_tree_id = getattr(right_sibling, self.tree_id_attr)
```
`get_next_sibling()` can return `None` (it's mentioned in the docstring), but that case isn't handled and so fails with `AttributeError: 'NoneType' object has no attribute 'tree_id'`

Can you suggest an appropriate resolution?