### PR TITLE
Use default tree manager when multiple tree managers are defined

### DIFF
--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -283,6 +283,22 @@ class SwappedInModel(MPTTModel):
     name = models.CharField(max_length=50)
 
 
+# Default manager
+class MultipleManager(TreeManager):
+    def get_queryset(self):
+        return super(MultipleManager, self).get_queryset().exclude(published=False)
+
+
+class MultipleManagerModel(MPTTModel):
+    parent = TreeForeignKey(
+        'self', null=True, blank=True, related_name='children',
+        on_delete=models.CASCADE)
+    published = models.BooleanField()
+
+    objects = TreeManager()
+    foo_objects = MultipleManager()
+
+
 class AutoNowDateFieldModel(MPTTModel):
     parent = TreeForeignKey(
         'self', null=True, blank=True, related_name='children',

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -40,7 +40,7 @@ from myapp.models import (
     Category, Item, Genre, CustomPKName, SingleProxyModel, DoubleProxyModel,
     ConcreteModel, OrderedInsertion, AutoNowDateFieldModel, Person,
     CustomTreeQueryset, Node, ReferencingModel, CustomTreeManager, Book,
-    UUIDNode, Student)
+    UUIDNode, Student, MultipleManagerModel)
 
 
 def get_tree_details(nodes):
@@ -1298,6 +1298,13 @@ class ManagerTests(TreeTestCase):
             qs = Category.objects.get_queryset_descendants(
                 Category.objects.all(), include_self=True)
             self.assertEqual(len(qs), 10)
+
+    def test_default_manager_with_multiple_managers(self):
+        """
+        Test that a model with multiple managers defined always uses the
+        default manager as the tree manager.
+        """
+        self.assertEqual(type(MultipleManagerModel._tree_manager), TreeManager)
 
 
 class CacheTreeChildrenTestCase(TreeTestCase):


### PR DESCRIPTION
Fixes #499. Bug only happens on Django < 1.10.