### PR TITLE
Fixed MIDDLEWARE_CLASSES deprecated warning.

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 import os
 
+import django
+
 DIRNAME = os.path.dirname(__file__)
 
 DEBUG = True
@@ -31,10 +33,12 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 ]
+
 # Compatibility for Django < 1.10
-MIDDLEWARE_CLASSES = MIDDLEWARE + [
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware'
-]
+if django.VERSION < (1, 10):
+    MIDDLEWARE_CLASSES = MIDDLEWARE + [
+        'django.contrib.auth.middleware.SessionAuthenticationMiddleware'
+    ]
 
 TEMPLATES = [
     {


### PR DESCRIPTION
Fixed `MIDDLEWARE_CLASSES` deprecation warning in test suite:

```
?: (1_10.W001) The MIDDLEWARE_CLASSES setting is deprecated in Django 1.10
and the MIDDLEWARE setting takes precedence. Since you've set MIDDLEWARE,
the value of MIDDLEWARE_CLASSES is ignored.
```