### PR TITLE
Fix print_debug_info with non-ascii object representation

### DIFF
--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -8,7 +8,7 @@ import csv
 import itertools
 import sys
 
-from django.utils.six import next, text_type
+from django.utils.six import next, PY3, text_type
 from django.utils.six.moves import zip
 from django.utils.translation import ugettext as _
 
@@ -174,7 +174,14 @@ def print_debug_info(qs, file=None):
         row = []
         for field in header[:-1]:
             row.append(getattr(n, field))
-        row.append('%s%s' % ('- ' * level, text_type(n).encode('utf-8')))
+
+        row_text = '%s%s' % ('- ' * level, text_type(n))
+        # Python 3 expects CSV data to be unicode, Python 2 expects it to be
+        # encoded
+        if PY3:
+            row.append(row_text)
+        else:
+            row.append(row_text.encode('utf-8'))
         writer.writerow(row)
 
 

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import io
@@ -1573,13 +1574,29 @@ class TestAltersData(TreeTestCase):
 class TestDebugInfo(TreeTestCase):
     fixtures = ['categories.json']
 
+    def get_stream_type(self):
+        return io.StringIO if PY3 else io.BytesIO
+
+    def decode_stream(self, stream):
+        return stream if PY3 else stream.decode('utf-8')
+
     def test_debug_info(self):  # Currently fails either on PY2 or PY3.
-        stream_type = io.StringIO if PY3 else io.BytesIO
+        stream_type = self.get_stream_type()
         with stream_type() as out:
             print_debug_info(Category.objects.all(), file=out)
             output = out.getvalue()
 
-        self.assertIn('1,0,,1,1,20', output)
+        self.assertIn('1,0,,1,1,20', self.decode_stream(output))
+
+    def test_debug_info_with_non_ascii_representations(self):
+        Category.objects.create(name='El niño')
+
+        stream_type = self.get_stream_type()
+        with stream_type() as out:
+            print_debug_info(Category.objects.all(), file=out)
+            output = out.getvalue()
+
+        self.assertIn('El niño', self.decode_stream(output))
 
 
 class AdminBatch(TreeTestCase):


### PR DESCRIPTION
If you run `print_debug_info` and your objects have non-ascii characters in their unicode representation, you'll get a `UnicodeDecodeError`.