### PR TITLE
Fixed PEP8.

### DIFF
--- a/mptt/fields.py
+++ b/mptt/fields.py
@@ -39,6 +39,7 @@ class TreeManyToManyField(models.ManyToManyField):
         kwargs.setdefault('form_class', TreeNodeMultipleChoiceField)
         return super(TreeManyToManyField, self).formfield(**kwargs)
 
+
 # South integration
 if 'south' in settings.INSTALLED_APPS:  # pragma: no cover
     from south.modelsinspector import add_introspection_rules

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -47,6 +47,7 @@ class classpropertytype(property):
             members.get('__doc__')
         )
 
+
 classproperty = classpropertytype('classproperty')
 
 
@@ -213,7 +214,8 @@ class MPTTOptions(object):
                 # Fall back on tree id ordering if multiple root nodes have
                 # the same values.
                 order_by.append(opts.tree_id_attr)
-            queryset = node.__class__._tree_manager.db_manager(node._state.db).filter(filters).order_by(*order_by)
+            queryset = node.__class__._tree_manager.db_manager(
+                node._state.db).filter(filters).order_by(*order_by)
             if node.pk:
                 queryset = queryset.exclude(pk=node.pk)
             try:
@@ -344,7 +346,8 @@ class MPTTModelBase(ModelBase):
                 else:
                     if hasattr(cls._meta, 'concrete_managers'):  # Django < 1.10
                         # Django < 1.10 doesn't sort managers
-                        cls_managers = sorted(cls._meta.concrete_managers + cls._meta.abstract_managers)
+                        cls_managers = sorted(
+                            cls._meta.concrete_managers + cls._meta.abstract_managers)
                         cls_managers = [r[2] for r in cls_managers]
                     else:
                         cls_managers = cls._meta.managers

--- a/mptt/templatetags/mptt_admin.py
+++ b/mptt/templatetags/mptt_admin.py
@@ -178,7 +178,9 @@ def mptt_items_for_result(cl, result, form):
             except NoReverseMatch:
                 link_or_text = result_repr
             else:
-                url = add_preserved_filters({'preserved_filters': cl.preserved_filters, 'opts': cl.opts}, url)
+                url = add_preserved_filters(
+                    {'preserved_filters': cl.preserved_filters, 'opts': cl.opts}, url,
+                )
                 # Convert the pk to something that can be used in Javascript.
                 # Problem cases are long ints (23L) and non-ASCII strings.
                 if cl.to_field:
@@ -189,7 +191,8 @@ def mptt_items_for_result(cl, result, form):
                 if cl.is_popup:
                     if django.VERSION < (1, 10):
                         opener = format_html(
-                            ' onclick="opener.dismissRelatedLookupPopup(window, &#39;{}&#39;); return false;"', value
+                            ' onclick="opener.dismissRelatedLookupPopup(window, &#39;{}&#39;);'
+                            ' return false;"', value
                         )
                     else:
                         opener = format_html(
@@ -244,6 +247,7 @@ def mptt_result_list(cl):
             'result_hidden_fields': list(result_hidden_fields(cl)),
             'result_headers': list(result_headers(cl)),
             'results': list(mptt_results(cl))}
+
 
 # custom template is merely so we can strip out sortable-ness from the column headers
 # Based on admin/change_list_results.html (1.3.1)

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -315,6 +315,7 @@ class AutoNowDateFieldModel(MPTTModel):
 class Group(models.Model):
     name = models.CharField(max_length=100)
 
+
 TreeForeignKey(
     Group, blank=True, null=True, on_delete=models.CASCADE
 ).contribute_to_class(Group, 'parent')

--- a/tests/myapp/test_forms.py
+++ b/tests/myapp/test_forms.py
@@ -124,12 +124,11 @@ class TestForms(TreeTestCase):
             str(form['target'])
         )
         form = MoveNodeForm(Genre.objects.get(pk=7), position_choices=(('left', 'left'),))
-        self.assertHTMLEqual(
-            str(form['position']),
-            ('<select id="id_position" name="position" {required}>'
+        self.assertHTMLEqual(str(form['position']), (
+            '<select id="id_position" name="position" {required}>'
             '<option value="left">left</option>'
-            '</select>').format(required='required' if required_on_select_without_empty else '')
-        )
+            '</select>'
+        ).format(required='required' if required_on_select_without_empty else ''))
 
     def test_treenodechoicefield(self):
         field = TreeNodeChoiceField(queryset=Genre.objects.all())

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -56,6 +56,7 @@ def get_tree_details(nodes):
                        getattr(n, opts.left_attr), getattr(n, opts.right_attr))
                       for n in nodes])
 
+
 leading_whitespace_re = re.compile(r'^\s+', re.MULTILINE)
 
 


### PR DESCRIPTION
Small cleanup. I fixed PEP8 issues:
```
./mptt/fields.py:43:1: E305 expected 2 blank lines after class or function definition, found 1
./mptt/models.py:50:1: E305 expected 2 blank lines after class or function definition, found 1
./mptt/models.py:216:100: E501 line too long (114 > 99 characters)
./mptt/models.py:347:100: E501 line too long (104 > 99 characters)
./mptt/templatetags/mptt_admin.py:181:100: E501 line too long (110 > 99 characters)
./mptt/templatetags/mptt_admin.py:192:100: E501 line too long (117 > 99 characters)
./mptt/templatetags/mptt_admin.py:250:1: E305 expected 2 blank lines after class or function definition, found 1
./tests/myapp/models.py:318:1: E305 expected 2 blank lines after class or function definition, found 1
./tests/myapp/tests.py:59:1: E305 expected 2 blank lines after class or function definition, found 1
./tests/myapp/test_forms.py:130:13: E128 continuation line under-indented for visual indent
./tests/myapp/test_forms.py:131:13: E128 continuation line under-indented for visual indent
```