### PR TITLE
Fetch CSRF token from hidden input field instead of cookie

### DIFF
--- a/mptt/static/mptt/draggable-admin.js
+++ b/mptt/static/mptt/draggable-admin.js
@@ -81,23 +81,6 @@ django.jQuery(function($){
         }
     }
 
-    /* Thanks, Django */
-    function getCookie(name) {
-        var cookieValue = null;
-        if (document.cookie && document.cookie != '') {
-            var cookies = document.cookie.split(';');
-            for (var i = 0; i < cookies.length; i++) {
-                var cookie = $.trim(cookies[i]);
-                // Does this cookie string begin with the name we want?
-                if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                    cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                    break;
-                }
-            }
-        }
-        return cookieValue;
-    }
-
     /*
      * FeinCMS Drag-n-drop tree reordering.
      * Based upon code by bright4 for Radiant CMS, rewritten for
@@ -248,7 +231,7 @@ django.jQuery(function($){
                                 pasted_on: pastedOn
                             },
                             headers: {
-                                'X-CSRFToken': getCookie('csrftoken')
+                                'X-CSRFToken': $('input[type=hidden][name=csrfmiddlewaretoken]').val()
                             },
                             method: 'POST'
                         });


### PR DESCRIPTION
If Django parameter `CSRF_COOKIE_HTTPONLY` [1] is set as recommended by
`manage.py check --deploy`, client-side JavaScript will not to be able
to access the CSRF cookie [2].

This, in turn, breaks Ajax POST requests, so avoid trying to read it
from the cookie and fetch CSRF token from a hidden form field instead.

[1]: https://docs.djangoproject.com/en/1.10/ref/settings/#csrf-cookie-httponly
[2]: https://www.owasp.org/index.php/HttpOnly#What_is_HttpOnly.3F

Signed-off-by: Yury V. Zaytsev <yury@shurup.com>