### PR TITLE
Fixed tests.myapp.tests.AdminBatch.test_changelist.

### DIFF
--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -1615,7 +1615,7 @@ class AdminBatch(TreeTestCase):
             10)
 
         mptt_opts = Category._mptt_meta
-        self.assertEqual(
+        self.assertSequenceEqual(
             response.context['cl'].result_list.query.order_by[:2],
             [mptt_opts.tree_id_attr, mptt_opts.left_attr])
 


### PR DESCRIPTION
Fixed `tests.myapp.tests.AdminBatch.test_changelist`. Since Django > 1.11 `order_by` is a `tuple` not a `list` (see https://github.com/django/django/commit/af121b08e85f2afe9c15dd66cb73f5d99515a604).