### PR TITLE
No magic

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -124,7 +124,7 @@ recommend using the following code::
         def something(self, instance):
             return format_html(
                 '<div style="text-indent:{}px">{}</div>',
-                instance._mpttfield('level') * self.mptt_level_indent,
+                instance.level * self.mptt_level_indent,
                 instance.name,  # Or whatever you want to put here
             )
         something.short_description = _('something nice')

--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -66,7 +66,7 @@ class MPTTModelAdmin(ModelAdmin):
         Changes the default ordering for changelists to tree-order.
         """
         mptt_opts = self.model._mptt_meta
-        return self.ordering or (mptt_opts.tree_id_attr, mptt_opts.left_attr)
+        return self.ordering or ('tree_id', 'lft')
 
     def delete_selected_tree(self, modeladmin, request, queryset):
         """
@@ -167,7 +167,7 @@ class DraggableMPTTAdmin(MPTTModelAdmin):
             '<div class="tree-node" data-pk="{}" data-level="{}"'
             ' data-url="{}"></div>',
             item.pk,
-            item._mpttfield('level'),
+            item.level,
             url,
         )
     tree_actions.short_description = ''
@@ -179,7 +179,7 @@ class DraggableMPTTAdmin(MPTTModelAdmin):
         """
         return format_html(
             '<div style="text-indent:{}px">{}</div>',
-            item._mpttfield('level') * self.mptt_level_indent,
+            item.level * self.mptt_level_indent,
             item,
         )
     indented_title.short_description = ugettext_lazy('title')
@@ -345,7 +345,7 @@ class TreeRelatedFieldListFilter(RelatedFieldListFilter):
         initial_choices = field.get_choices(include_blank=False)
         pks = [pk for pk, val in initial_choices]
         models = field.related_model._default_manager.filter(pk__in=pks)
-        levels_dict = {model.pk: getattr(model, model._mptt_meta.level_attr) for model in models}
+        levels_dict = {model.pk: model.level for model in models}
         choices = []
         for pk, val in initial_choices:
             padding_style = ' style="padding-%s:%spx"' % (

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -540,7 +540,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             space_target, level, left, parent, right_shift = \
                 self._calculate_inter_tree_move_values(node, target, position)
 
-            self._create_space(2, space_target, target.tree_id)
+            self._manage_space(2, space_target, target.tree_id)
 
             node.lft = -left
             node.rght = -left + 1
@@ -728,20 +728,6 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             right_shift = 2 * (node.get_descendant_count() + 1)
 
         return space_target, level_change, left_right_change, parent, right_shift
-
-    def _close_gap(self, size, target, tree_id):
-        """
-        Closes a gap of a certain ``size`` after the given ``target``
-        point in the tree identified by ``tree_id``.
-        """
-        self._manage_space(-size, target, tree_id)
-
-    def _create_space(self, size, target, tree_id):
-        """
-        Creates a space of a certain ``size`` after the given ``target``
-        point in the tree identified by ``tree_id``.
-        """
-        self._manage_space(size, target, tree_id)
 
     def _create_tree_space(self, target_tree_id, num_trees=1):
         """
@@ -994,7 +980,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         tree_width = right - left + 1
 
         # Make space for the subtree which will be moved
-        self._create_space(tree_width, space_target, new_tree_id)
+        self._manage_space(tree_width, space_target, new_tree_id)
         # Move the subtree
         connection = self._get_connection(instance=node)
         self._inter_tree_move_and_close_gap(
@@ -1151,7 +1137,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             self._calculate_inter_tree_move_values(node, target, position)
 
         # Create space for the tree which will be inserted
-        self._create_space(width, space_target, new_tree_id)
+        self._manage_space(width, space_target, new_tree_id)
 
         # Move the root node, making it a child node
         connection = self._get_connection(instance=node)

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import functools
 import contextlib
 from itertools import groupby
+import warnings
 
 from django.db import models, connections, router
 from django.db.models import F, ManyToManyField, Max, Q
@@ -33,9 +34,9 @@ CUMULATIVE_COUNT_SUBQUERY = """(
     (
         SELECT m2.%(mptt_rel_to)s
         FROM %(mptt_table)s m2
-        WHERE m2.%(tree_id)s = %(mptt_table)s.%(tree_id)s
-          AND m2.%(left)s BETWEEN %(mptt_table)s.%(left)s
-                              AND %(mptt_table)s.%(right)s
+        WHERE m2.tree_id = %(mptt_table)s.tree_id
+          AND m2.lft BETWEEN %(mptt_table)s.lft
+                              AND %(mptt_table)s.rght
     )
 )"""
 
@@ -54,9 +55,9 @@ CUMULATIVE_COUNT_SUBQUERY_M2M = """(
     (
         SELECT m2.%(mptt_pk)s
         FROM %(mptt_table)s m2
-        WHERE m2.%(tree_id)s = %(mptt_table)s.%(tree_id)s
-          AND m2.%(left)s BETWEEN %(mptt_table)s.%(left)s
-                              AND %(mptt_table)s.%(right)s
+        WHERE m2.tree_id = %(mptt_table)s.tree_id
+          AND m2.lft BETWEEN %(mptt_table)s.lft
+                              AND %(mptt_table)s.rght
     )
 )"""
 
@@ -96,9 +97,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         """
         return super(TreeManager, self).get_queryset(
             *args, **kwargs
-        ).order_by(
-            self.tree_id_attr, self.left_attr
-        )
+        ).order_by('tree_id', 'lft')
 
     def _get_queryset_relatives(self, queryset, direction, include_self):
         """
@@ -115,7 +114,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         This function works by grouping contiguous siblings and using them to create
         a range that selects all nodes between the range, instead of querying for each
         node individually. Three variables are required when querying for ancestors or
-        descendants: tree_id_attr, left_attr, right_attr. If we weren't using ranges
+        descendants: tree_id, lft, rght. If we weren't using ranges
         and our queryset contained 100 results, the resulting SQL query would contain
         300 variables. However, when using ranges, if the same queryset contained 10
         sets of contiguous siblings, then the resulting SQL query should only contain
@@ -126,11 +125,11 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
         * Ascending (ancestor nodes): select all nodes whose right_attr is greater
           than (or equal to, if include_self = True) the smallest right_attr within
-          the set of contiguous siblings, and whose left_attr is less than (or equal
-          to) the largest left_attr within the set of contiguous siblings.
+          the set of contiguous siblings, and whose lft is less than (or equal
+          to) the largest lft within the set of contiguous siblings.
 
-        * Descending (descendant nodes): select all nodes whose left_attr is greater
-          than (or equal to, if include_self = True) the smallest left_attr within
+        * Descending (descendant nodes): select all nodes whose lft is greater
+          than (or equal to, if include_self = True) the smallest lft within
           the set of contiguous siblings, and whose right_attr is less than (or equal
           to) the largest right_attr within the set of contiguous siblings.
 
@@ -147,20 +146,19 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         max_op = 'lt' + e
         min_op = 'gt' + e
         if direction == 'asc':
-            max_attr = opts.left_attr
-            min_attr = opts.right_attr
+            max_attr = 'lft'
+            min_attr = 'rght'
         elif direction == 'desc':
-            max_attr = opts.right_attr
-            min_attr = opts.left_attr
+            max_attr = 'rght'
+            min_attr = 'lft'
 
-        tree_key = opts.tree_id_attr
         min_key = '%s__%s' % (min_attr, min_op)
         max_key = '%s__%s' % (max_attr, max_op)
 
-        q = queryset.order_by(opts.tree_id_attr, opts.parent_attr, opts.left_attr).only(
-            opts.tree_id_attr,
-            opts.left_attr,
-            opts.right_attr,
+        q = queryset.order_by('tree_id', opts.parent_attr, 'lft').only(
+            'tree_id',
+            'lft',
+            'rght',
             min_attr,
             max_attr,
             opts.parent_attr,
@@ -174,16 +172,18 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         for group in groupby(
                 q,
                 key=lambda n: (
-                    getattr(n, opts.tree_id_attr),
+                    n.tree_id,
                     getattr(n, opts.parent_attr + '_id'),
                 )):
             next_lft = None
             for node in list(group[1]):
-                tree, lft, rght, min_val, max_val = (getattr(node, opts.tree_id_attr),
-                                                     getattr(node, opts.left_attr),
-                                                     getattr(node, opts.right_attr),
-                                                     getattr(node, min_attr),
-                                                     getattr(node, max_attr))
+                tree, lft, rght, min_val, max_val = (
+                    node.tree_id,
+                    node.lft,
+                    node.rght,
+                    getattr(node, min_attr),
+                    getattr(node, max_attr),
+                )
                 if next_lft is None:
                     next_lft = rght + 1
                     min_max = {'min': min_val, 'max': max_val}
@@ -195,14 +195,14 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                     next_lft = rght + 1
                 elif lft != next_lft:
                     filters |= Q(**{
-                        tree_key: tree,
+                        'tree_id': tree,
                         min_key: min_max['min'],
                         max_key: min_max['max'],
                     })
                     min_max = {'min': min_val, 'max': max_val}
                     next_lft = rght + 1
             filters |= Q(**{
-                tree_key: tree,
+                'tree_id': tree,
                 min_key: min_max['min'],
                 max_key: min_max['max'],
             })
@@ -371,22 +371,6 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
     def parent_attr(self):
         return self.model._mptt_meta.parent_attr
 
-    @property
-    def left_attr(self):
-        return self.model._mptt_meta.left_attr
-
-    @property
-    def right_attr(self):
-        return self.model._mptt_meta.right_attr
-
-    @property
-    def tree_id_attr(self):
-        return self.model._mptt_meta.tree_id_attr
-
-    @property
-    def level_attr(self):
-        return self.model._mptt_meta.level_attr
-
     def _translate_lookups(self, **lookups):
         new_lookups = {}
         join_parts = '__'.join
@@ -405,6 +389,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         Like ``self.filter()``, but translates name-agnostic filters for MPTT
         fields.
         """
+        warnings.warn('Stop doing that.', DeprecationWarning, stacklevel=2)
         if qs is None:
             qs = self
         return qs.filter(**self._translate_lookups(**filters))
@@ -463,9 +448,6 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                     'mptt_fk': qn(mptt_field.m2m_reverse_name()),
                     'mptt_table': qn(self.tree_model._meta.db_table),
                     'mptt_pk': qn(meta.pk.column),
-                    'tree_id': qn(meta.get_field(self.tree_id_attr).column),
-                    'left': qn(meta.get_field(self.left_attr).column),
-                    'right': qn(meta.get_field(self.right_attr).column),
                 }
             else:
                 subquery = COUNT_SUBQUERY_M2M % {
@@ -484,9 +466,6 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                     'mptt_fk': qn(rel_model._meta.get_field(rel_field).column),
                     'mptt_table': qn(self.tree_model._meta.db_table),
                     'mptt_rel_to': qn(remote_field(mptt_field).field_name),
-                    'tree_id': qn(meta.get_field(self.tree_id_attr).column),
-                    'left': qn(meta.get_field(self.left_attr).column),
-                    'right': qn(meta.get_field(self.right_attr).column),
                 }
             else:
                 subquery = COUNT_SUBQUERY % {
@@ -523,10 +502,10 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
         if target is None:
             tree_id = self._get_next_tree_id()
-            setattr(node, self.left_attr, 1)
-            setattr(node, self.right_attr, 2)
-            setattr(node, self.level_attr, 0)
-            setattr(node, self.tree_id_attr, tree_id)
+            node.lft = 1
+            node.rght = 2
+            node.level = 0
+            node.tree_id = tree_id
             setattr(node, self.parent_attr, None)
         elif target.is_root_node() and position in ['left', 'right']:
             if refresh_target:
@@ -534,7 +513,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                 target.refresh_from_db(fields=(
                     'lft', 'rght', 'level', 'tree_id'))
 
-            target_tree_id = getattr(target, self.tree_id_attr)
+            target_tree_id = target.tree_id
             if position == 'left':
                 tree_id = target_tree_id
                 space_target = target_tree_id - 1
@@ -543,14 +522,14 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                 space_target = target_tree_id
             self._create_tree_space(space_target)
 
-            setattr(node, self.left_attr, 1)
-            setattr(node, self.right_attr, 2)
-            setattr(node, self.level_attr, 0)
-            setattr(node, self.tree_id_attr, tree_id)
+            node.lft = 1
+            node.rght = 2
+            node.level = 0
+            node.tree_id = tree_id
             setattr(node, self.parent_attr, None)
         else:
-            setattr(node, self.left_attr, 0)
-            setattr(node, self.level_attr, 0)
+            node.lft = 0
+            node.level = 0
 
             if refresh_target:
                 # Ensure mptt values on target are not stale.
@@ -561,13 +540,12 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             space_target, level, left, parent, right_shift = \
                 self._calculate_inter_tree_move_values(node, target, position)
 
-            tree_id = getattr(target, self.tree_id_attr)
-            self._create_space(2, space_target, tree_id)
+            self._create_space(2, space_target, target.tree_id)
 
-            setattr(node, self.left_attr, -left)
-            setattr(node, self.right_attr, -left + 1)
-            setattr(node, self.level_attr, -level)
-            setattr(node, self.tree_id_attr, tree_id)
+            node.lft = -left
+            node.rght = -left + 1
+            node.level = -level
+            node.tree_id = target.tree_id
             setattr(node, self.parent_attr, parent)
 
             if parent:
@@ -693,8 +671,8 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         qs = self.model._default_manager.filter(pk=pk)
         self._mptt_update(
             qs,
-            left=left,
-            right=right,
+            lft=left,
+            rght=right,
             level=level,
             tree_id=tree_id
         )
@@ -702,7 +680,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         return right + 1
 
     def _post_insert_update_cached_parent_right(self, instance, right_shift, seen=None):
-        setattr(instance, self.right_attr, getattr(instance, self.right_attr) + right_shift)
+        instance.rght += right_shift
         attr = '_%s_cache' % self.parent_attr
         if hasattr(instance, attr):
             parent = getattr(instance, attr)
@@ -720,11 +698,11 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         Calculates values required when moving ``node`` relative to
         ``target`` as specified by ``position``.
         """
-        left = getattr(node, self.left_attr)
-        level = getattr(node, self.level_attr)
-        target_left = getattr(target, self.left_attr)
-        target_right = getattr(target, self.right_attr)
-        target_level = getattr(target, self.level_attr)
+        left = node.lft
+        level = node.level
+        target_left = target.lft
+        target_right = target.rght
+        target_level = target.level
 
         if position == 'last-child' or position == 'first-child':
             if position == 'last-child':
@@ -771,7 +749,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         greater than ``target_tree_id``.
         """
         qs = self._mptt_filter(tree_id__gt=target_tree_id)
-        self._mptt_update(qs, tree_id=F(self.tree_id_attr) + num_trees)
+        self._mptt_update(qs, tree_id=F('tree_id') + num_trees)
         self.tree_model._mptt_track_tree_insertions(target_tree_id + 1, num_trees)
 
     def _get_next_tree_id(self):
@@ -779,9 +757,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         Determines the next largest unused tree id for the tree managed
         by this manager.
         """
-        max_tree_id = list(self.aggregate(Max(self.tree_id_attr)).values())[0]
-        max_tree_id = max_tree_id or 0
-        return max_tree_id + 1
+        return 1 + (self.aggregate(m=Max('tree_id'))['m'] or 0)
 
     def _inter_tree_move_and_close_gap(
             self, node, level_change,
@@ -799,39 +775,34 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         connection = self._get_connection(instance=node)
         qn = connection.ops.quote_name
 
-        opts = self.model._meta
         inter_tree_move_query = """
         UPDATE %(table)s
-        SET %(level)s = CASE
-                WHEN %(left)s >= %%s AND %(left)s <= %%s
-                    THEN %(level)s - %%s
-                ELSE %(level)s END,
-            %(tree_id)s = CASE
-                WHEN %(left)s >= %%s AND %(left)s <= %%s
+        SET level = CASE
+                WHEN lft >= %%s AND lft <= %%s
+                    THEN level - %%s
+                ELSE level END,
+            tree_id = CASE
+                WHEN lft >= %%s AND lft <= %%s
                     THEN %%s
-                ELSE %(tree_id)s END,
-            %(left)s = CASE
-                WHEN %(left)s >= %%s AND %(left)s <= %%s
-                    THEN %(left)s - %%s
-                WHEN %(left)s > %%s
-                    THEN %(left)s - %%s
-                ELSE %(left)s END,
-            %(right)s = CASE
-                WHEN %(right)s >= %%s AND %(right)s <= %%s
-                    THEN %(right)s - %%s
-                WHEN %(right)s > %%s
-                    THEN %(right)s - %%s
-                ELSE %(right)s END
-        WHERE %(tree_id)s = %%s""" % {
+                ELSE tree_id END,
+            lft = CASE
+                WHEN lft >= %%s AND lft <= %%s
+                    THEN lft - %%s
+                WHEN lft > %%s
+                    THEN lft - %%s
+                ELSE lft END,
+            rght = CASE
+                WHEN rght >= %%s AND rght <= %%s
+                    THEN rght - %%s
+                WHEN rght > %%s
+                    THEN rght - %%s
+                ELSE rght END
+        WHERE tree_id = %%s""" % {
             'table': qn(self.tree_model._meta.db_table),
-            'level': qn(opts.get_field(self.level_attr).column),
-            'left': qn(opts.get_field(self.left_attr).column),
-            'tree_id': qn(opts.get_field(self.tree_id_attr).column),
-            'right': qn(opts.get_field(self.right_attr).column),
         }
 
-        left = getattr(node, self.left_attr)
-        right = getattr(node, self.right_attr)
+        left = node.lft
+        right = node.rght
         gap_size = right - left + 1
         gap_target_left = left - 1
         params = [
@@ -841,7 +812,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             gap_target_left, gap_size,
             left, right, left_right_change,
             gap_target_left, gap_size,
-            getattr(node, self.tree_id_attr)
+            node.tree_id,
         ]
 
         cursor = connection.cursor()
@@ -858,9 +829,9 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         ``node`` will be modified to reflect its new tree state in the
         database.
         """
-        left = getattr(node, self.left_attr)
-        right = getattr(node, self.right_attr)
-        level = getattr(node, self.level_attr)
+        left = node.lft
+        right = node.rght
+        level = node.level
         if not new_tree_id:
             new_tree_id = self._get_next_tree_id()
         left_right_change = left - 1
@@ -869,10 +840,10 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
         # Update the node to be consistent with the updated
         # tree in the database.
-        setattr(node, self.left_attr, left - left_right_change)
-        setattr(node, self.right_attr, right - left_right_change)
-        setattr(node, self.level_attr, 0)
-        setattr(node, self.tree_id_attr, new_tree_id)
+        node.lft = left - left_right_change
+        node.rght = right - left_right_change
+        node.level = 0
+        node.tree_id = new_tree_id
         setattr(node, self.parent_attr, None)
         node._mptt_cached_fields[self.parent_attr] = None
 
@@ -892,9 +863,8 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         if node == target:
             raise InvalidMove(_('A node may not be made a sibling of itself.'))
 
-        opts = self.model._meta
-        tree_id = getattr(node, self.tree_id_attr)
-        target_tree_id = getattr(target, self.tree_id_attr)
+        tree_id = node.tree_id
+        target_tree_id = target.tree_id
 
         if node.is_child_node():
             if position == 'left':
@@ -912,7 +882,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                 # database - this change must be reflected in the node
                 # object for the method call below to operate on the
                 # correct tree.
-                setattr(node, self.tree_id_attr, tree_id + 1)
+                node.tree_id = tree_id + 1
             self._make_child_root_node(node, new_tree_id)
         else:
             if position == 'left':
@@ -920,7 +890,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                     left_sibling = target.get_previous_sibling()
                     if node == left_sibling:
                         return
-                    new_tree_id = getattr(left_sibling, self.tree_id_attr)
+                    new_tree_id = left_sibling.tree_id
                     lower_bound, upper_bound = tree_id, new_tree_id
                     shift = -1
                 else:
@@ -936,7 +906,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                     right_sibling = target.get_next_sibling()
                     if node == right_sibling:
                         return
-                    new_tree_id = getattr(right_sibling, self.tree_id_attr)
+                    new_tree_id = right_sibling.tree_id
                     lower_bound, upper_bound = new_tree_id, tree_id
                     shift = 1
             else:
@@ -947,19 +917,18 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
             root_sibling_query = """
             UPDATE %(table)s
-            SET %(tree_id)s = CASE
-                WHEN %(tree_id)s = %%s
+            SET tree_id = CASE
+                WHEN tree_id = %%s
                     THEN %%s
-                ELSE %(tree_id)s + %%s END
-            WHERE %(tree_id)s >= %%s AND %(tree_id)s <= %%s""" % {
+                ELSE tree_id + %%s END
+            WHERE tree_id >= %%s AND tree_id <= %%s""" % {
                 'table': qn(self.tree_model._meta.db_table),
-                'tree_id': qn(opts.get_field(self.tree_id_attr).column),
             }
 
             cursor = connection.cursor()
             cursor.execute(root_sibling_query, [tree_id, new_tree_id, shift,
                                                 lower_bound, upper_bound])
-            setattr(node, self.tree_id_attr, new_tree_id)
+            node.tree_id = new_tree_id
 
     def _manage_space(self, size, target, tree_id):
         """
@@ -973,23 +942,19 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             connection = self._get_connection()
             qn = connection.ops.quote_name
 
-            opts = self.model._meta
             space_query = """
             UPDATE %(table)s
-            SET %(left)s = CASE
-                    WHEN %(left)s > %%s
-                        THEN %(left)s + %%s
-                    ELSE %(left)s END,
-                %(right)s = CASE
-                    WHEN %(right)s > %%s
-                        THEN %(right)s + %%s
-                    ELSE %(right)s END
-            WHERE %(tree_id)s = %%s
-              AND (%(left)s > %%s OR %(right)s > %%s)""" % {
+            SET lft = CASE
+                    WHEN lft > %%s
+                        THEN lft + %%s
+                    ELSE lft END,
+                rght = CASE
+                    WHEN rght > %%s
+                        THEN rght + %%s
+                    ELSE rght END
+            WHERE tree_id = %%s
+              AND (lft > %%s OR rght > %%s)""" % {
                 'table': qn(self.tree_model._meta.db_table),
-                'left': qn(opts.get_field(self.left_attr).column),
-                'right': qn(opts.get_field(self.right_attr).column),
-                'tree_id': qn(opts.get_field(self.tree_id_attr).column),
             }
             cursor = connection.cursor()
             cursor.execute(space_query, [target, size, target, size, tree_id,
@@ -1001,8 +966,8 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         relative to the given ``target`` node as specified by
         ``position``.
         """
-        tree_id = getattr(node, self.tree_id_attr)
-        target_tree_id = getattr(target, self.tree_id_attr)
+        tree_id = node.tree_id
+        target_tree_id = target.tree_id
 
         if tree_id == target_tree_id:
             self._move_child_within_tree(node, target, position)
@@ -1018,10 +983,10 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         ``node`` will be modified to reflect its new tree state in the
         database.
         """
-        left = getattr(node, self.left_attr)
-        right = getattr(node, self.right_attr)
-        level = getattr(node, self.level_attr)
-        new_tree_id = getattr(target, self.tree_id_attr)
+        left = node.lft
+        right = node.rght
+        level = node.level
+        new_tree_id = target.tree_id
 
         space_target, level_change, left_right_change, parent, new_parent_right = \
             self._calculate_inter_tree_move_values(node, target, position)
@@ -1038,10 +1003,10 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
         # Update the node to be consistent with the updated
         # tree in the database.
-        setattr(node, self.left_attr, left - left_right_change)
-        setattr(node, self.right_attr, right - left_right_change)
-        setattr(node, self.level_attr, level - level_change)
-        setattr(node, self.tree_id_attr, new_tree_id)
+        node.lft = left - left_right_change
+        node.rght = right - left_right_change
+        node.level = level - level_change
+        node.tree_id = new_tree_id
         setattr(node, self.parent_attr, parent)
 
         node._mptt_cached_fields[self.parent_attr] = parent.pk
@@ -1054,14 +1019,14 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         ``node`` will be modified to reflect its new tree state in the
         database.
         """
-        left = getattr(node, self.left_attr)
-        right = getattr(node, self.right_attr)
-        level = getattr(node, self.level_attr)
+        left = node.lft
+        right = node.rght
+        level = node.level
         width = right - left + 1
-        tree_id = getattr(node, self.tree_id_attr)
-        target_left = getattr(target, self.left_attr)
-        target_right = getattr(target, self.right_attr)
-        target_level = getattr(target, self.level_attr)
+        tree_id = node.tree_id
+        target_left = target.lft
+        target_right = target.rght
+        target_level = target.level
 
         if position == 'last-child' or position == 'first-child':
             if node == target:
@@ -1118,35 +1083,30 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         connection = self._get_connection(instance=node)
         qn = connection.ops.quote_name
 
-        opts = self.model._meta
         # The level update must come before the left update to keep
         # MySQL happy - left seems to refer to the updated value
         # immediately after its update has been specified in the query
         # with MySQL, but not with SQLite or Postgres.
         move_subtree_query = """
         UPDATE %(table)s
-        SET %(level)s = CASE
-                WHEN %(left)s >= %%s AND %(left)s <= %%s
-                  THEN %(level)s - %%s
-                ELSE %(level)s END,
-            %(left)s = CASE
-                WHEN %(left)s >= %%s AND %(left)s <= %%s
-                  THEN %(left)s + %%s
-                WHEN %(left)s >= %%s AND %(left)s <= %%s
-                  THEN %(left)s + %%s
-                ELSE %(left)s END,
-            %(right)s = CASE
-                WHEN %(right)s >= %%s AND %(right)s <= %%s
-                  THEN %(right)s + %%s
-                WHEN %(right)s >= %%s AND %(right)s <= %%s
-                  THEN %(right)s + %%s
-                ELSE %(right)s END
-        WHERE %(tree_id)s = %%s""" % {
+        SET level = CASE
+                WHEN lft >= %%s AND lft <= %%s
+                  THEN level - %%s
+                ELSE level END,
+            lft = CASE
+                WHEN lft >= %%s AND lft <= %%s
+                  THEN lft + %%s
+                WHEN lft >= %%s AND lft <= %%s
+                  THEN lft + %%s
+                ELSE lft END,
+            rght = CASE
+                WHEN rght >= %%s AND rght <= %%s
+                  THEN rght + %%s
+                WHEN rght >= %%s AND rght <= %%s
+                  THEN rght + %%s
+                ELSE rght END
+        WHERE tree_id = %%s""" % {
             'table': qn(self.tree_model._meta.db_table),
-            'level': qn(opts.get_field(self.level_attr).column),
-            'left': qn(opts.get_field(self.left_attr).column),
-            'right': qn(opts.get_field(self.right_attr).column),
-            'tree_id': qn(opts.get_field(self.tree_id_attr).column),
         }
 
         cursor = connection.cursor()
@@ -1160,9 +1120,9 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
         # Update the node to be consistent with the updated
         # tree in the database.
-        setattr(node, self.left_attr, new_left)
-        setattr(node, self.right_attr, new_right)
-        setattr(node, self.level_attr, level - level_change)
+        node.lft = new_left
+        node.rght = new_right
+        node.level = level - level_change
         setattr(node, self.parent_attr, parent)
         node._mptt_cached_fields[self.parent_attr] = parent.pk
 
@@ -1175,11 +1135,11 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         ``node`` will be modified to reflect its new tree state in the
         database.
         """
-        left = getattr(node, self.left_attr)
-        right = getattr(node, self.right_attr)
-        level = getattr(node, self.level_attr)
-        tree_id = getattr(node, self.tree_id_attr)
-        new_tree_id = getattr(target, self.tree_id_attr)
+        left = node.lft
+        right = node.rght
+        level = node.level
+        tree_id = node.tree_id
+        new_tree_id = target.tree_id
         width = right - left + 1
 
         if node == target:
@@ -1197,20 +1157,15 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         connection = self._get_connection(instance=node)
         qn = connection.ops.quote_name
 
-        opts = self.model._meta
         move_tree_query = """
         UPDATE %(table)s
-        SET %(level)s = %(level)s - %%s,
-            %(left)s = %(left)s - %%s,
-            %(right)s = %(right)s - %%s,
-            %(tree_id)s = %%s
-        WHERE %(left)s >= %%s AND %(left)s <= %%s
-          AND %(tree_id)s = %%s""" % {
+        SET level = level - %%s,
+            lft = lft - %%s,
+            rght = rght - %%s,
+            tree_id = %%s
+        WHERE lft >= %%s AND lft <= %%s
+          AND tree_id = %%s""" % {
             'table': qn(self.tree_model._meta.db_table),
-            'level': qn(opts.get_field(self.level_attr).column),
-            'left': qn(opts.get_field(self.left_attr).column),
-            'right': qn(opts.get_field(self.right_attr).column),
-            'tree_id': qn(opts.get_field(self.tree_id_attr).column),
         }
 
         cursor = connection.cursor()
@@ -1221,9 +1176,9 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
         # Update the former root node to be consistent with the updated
         # tree in the database.
-        setattr(node, self.left_attr, left - left_right_change)
-        setattr(node, self.right_attr, right - left_right_change)
-        setattr(node, self.level_attr, level - level_change)
-        setattr(node, self.tree_id_attr, new_tree_id)
+        node.lft = left - left_right_change
+        node.rght = right - left_right_change
+        node.level = level - level_change
+        node.tree_id = new_tree_id
         setattr(node, self.parent_attr, parent)
         node._mptt_cached_fields[self.parent_attr] = parent.pk

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -916,11 +916,11 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                                                 lower_bound, upper_bound])
             node.tree_id = new_tree_id
 
-    def _manage_space(self, size, target, tree_id):
+    def _manage_space(self, width, right_of, tree_id):
         """
         Manages spaces in the tree identified by ``tree_id`` by changing
-        the values of the left and right columns by ``size`` after the
-        given ``target`` point.
+        the values of the left and right columns by ``width`` after the
+        given ``right_of`` point.
         """
         if self.tree_model._mptt_is_tracking:
             self.tree_model._mptt_track_tree_modified(tree_id)
@@ -943,8 +943,8 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
                 'table': qn(self.tree_model._meta.db_table),
             }
             cursor = connection.cursor()
-            cursor.execute(space_query, [target, size, target, size, tree_id,
-                                         target, target])
+            cursor.execute(space_query, [right_of, width, right_of, width, tree_id,
+                                         right_of, right_of])
 
     def _move_child_node(self, node, target, position):
         """

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -531,7 +531,8 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         elif target.is_root_node() and position in ['left', 'right']:
             if refresh_target:
                 # Ensure mptt values on target are not stale.
-                target._mptt_refresh()
+                target.refresh_from_db(fields=(
+                    'lft', 'rght', 'level', 'tree_id'))
 
             target_tree_id = getattr(target, self.tree_id_attr)
             if position == 'left':
@@ -553,7 +554,9 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
             if refresh_target:
                 # Ensure mptt values on target are not stale.
-                target._mptt_refresh()
+                target.refresh_from_db(fields=(
+                    'lft', 'rght', 'level', 'tree_id'))
+
 
             space_target, level, left, parent, right_shift = \
                 self._calculate_inter_tree_move_values(node, target, position)

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 from functools import reduce, wraps
 import operator
 import threading
+import warnings
 
 from django.db import models
 from django.db.models.base import ModelBase
@@ -15,7 +16,6 @@ from mptt.compat import remote_field
 from mptt.fields import TreeForeignKey, TreeOneToOneField, TreeManyToManyField
 from mptt.managers import TreeManager
 from mptt.signals import node_moved
-from mptt.utils import _get_tree_model
 
 
 __all__ = (
@@ -62,11 +62,27 @@ class MPTTOptions(object):
     """
 
     order_insertion_by = []
-    left_attr = 'lft'
-    right_attr = 'rght'
-    tree_id_attr = 'tree_id'
-    level_attr = 'level'
     parent_attr = 'parent'
+
+    @property
+    def left_attr(self):
+        warnings.warn('Use "lft" directly.', DeprecationWarning, stacklevel=2)
+        return 'lft'
+
+    @property
+    def right_attr(self):
+        warnings.warn('Use "rght" directly.', DeprecationWarning, stacklevel=2)
+        return 'rght'
+
+    @property
+    def tree_id_attr(self):
+        warnings.warn('Use "tree_id" directly.', DeprecationWarning, stacklevel=2)
+        return 'tree_id'
+
+    @property
+    def level_attr(self):
+        warnings.warn('Use "level" directly.', DeprecationWarning, stacklevel=2)
+        return 'level'
 
     def __init__(self, opts=None, **kwargs):
         # Override defaults with options provided
@@ -214,14 +230,13 @@ class MPTTOptions(object):
                 filters = filters & Q(**{opts.parent_attr: parent})
                 # Fall back on tree ordering if multiple child nodes have
                 # the same values.
-                order_by.append(opts.left_attr)
+                order_by.append('lft')
             else:
                 filters = filters & Q(**{opts.parent_attr: None})
                 # Fall back on tree id ordering if multiple root nodes have
                 # the same values.
-                order_by.append(opts.tree_id_attr)
-            queryset = node.__class__._tree_manager.db_manager(
-                node._state.db).filter(filters).order_by(*order_by)
+                order_by.append('tree_id')
+            queryset = node.__class__._tree_manager.db_manager(node._state.db).filter(filters).order_by(*order_by)
             if node.pk:
                 queryset = queryset.exclude(pk=node.pk)
             try:
@@ -327,21 +342,6 @@ class MPTTModelBase(ModelBase):
                 bases.insert(0, MPTTModel)
                 cls.__bases__ = tuple(bases)
 
-            if _get_tree_model(cls) is cls:
-                # HACK: _meta.get_field() doesn't work before AppCache.ready in Django>=1.8
-                # ( see https://code.djangoproject.com/ticket/24231 )
-                # So the only way to get existing fields is using local_fields on all superclasses.
-                existing_field_names = set()
-                for base in cls.mro():
-                    if hasattr(base, '_meta'):
-                        existing_field_names.update([f.name for f in base._meta.local_fields])
-
-                for key in ('left_attr', 'right_attr', 'tree_id_attr', 'level_attr'):
-                    field_name = getattr(cls._mptt_meta, key)
-                    if field_name not in existing_field_names:
-                        field = models.PositiveIntegerField(db_index=True, editable=False)
-                        field.contribute_to_class(cls, field_name)
-
             # Add a tree manager, if there isn't one already
             if not abstract:
                 # make sure we have a tree manager somewhere
@@ -393,18 +393,19 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
     Base class for tree models.
     """
 
-    class Meta:
-        abstract = True
+    lft = models.PositiveIntegerField(db_index=True, editable=False)
+    rght = models.PositiveIntegerField(db_index=True, editable=False)
+    tree_id = models.PositiveIntegerField(db_index=True, editable=False)
+    level = models.PositiveIntegerField(db_index=True, editable=False)
 
     objects = TreeManager()
+
+    class Meta:
+        abstract = True
 
     def __init__(self, *args, **kwargs):
         super(MPTTModel, self).__init__(*args, **kwargs)
         self._mptt_meta.update_mptt_cached_fields(self)
-
-    def _mpttfield(self, fieldname):
-        translated_fieldname = getattr(self._mptt_meta, fieldname + '_attr')
-        return getattr(self, translated_fieldname)
 
     @_classproperty
     def _mptt_updates_enabled(cls):
@@ -489,21 +490,21 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         else:
             opts = self._mptt_meta
 
-            order_by = opts.left_attr
+            order_by = 'lft'
             if ascending:
                 order_by = '-' + order_by
 
-            left = getattr(self, opts.left_attr)
-            right = getattr(self, opts.right_attr)
+            left = self.lft
+            right = self.rght
 
             if not include_self:
                 left -= 1
                 right += 1
 
             qs = self._tree_manager._mptt_filter(
-                left__lte=left,
-                right__gte=right,
-                tree_id=self._mpttfield('tree_id'),
+                lft__lte=left,
+                rght__gte=right,
+                tree_id=self.tree_id,
             )
 
             qs = qs.order_by(order_by)
@@ -532,22 +533,18 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         Returns a ``QuerySet`` containing the ancestors, the model itself
         and the descendants, in tree order.
         """
-        opts = self._mptt_meta
 
-        left = getattr(self, opts.left_attr)
-        right = getattr(self, opts.right_attr)
+        ancestors = Q(
+            lft__lte=self.lft,
+            rght__gte=self.rght,
+            tree_id=self.tree_id,
+        )
 
-        ancestors = Q(**{
-            "%s__lte" % opts.left_attr: left,
-            "%s__gte" % opts.right_attr: right,
-            opts.tree_id_attr: self._mpttfield('tree_id'),
-        })
-
-        descendants = Q(**{
-            "%s__gte" % opts.left_attr: left,
-            "%s__lte" % opts.left_attr: right,
-            opts.tree_id_attr: self._mpttfield('tree_id'),
-        })
+        descendants = Q(
+            lft__gte=self.lft,
+            rght__lte=self.rght,
+            tree_id=self.tree_id,
+        )
 
         return self._tree_manager.filter(ancestors | descendants)
 
@@ -590,29 +587,24 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
             else:
                 return self._tree_manager.filter(pk=self.pk)
 
-        opts = self._mptt_meta
-        left = getattr(self, opts.left_attr)
-        right = getattr(self, opts.right_attr)
+        left = self.lft
+        right = self.rght
 
         if not include_self:
             left += 1
             right -= 1
 
         return self._tree_manager._mptt_filter(
-            tree_id=self._mpttfield('tree_id'),
-            left__gte=left,
-            left__lte=right
+            tree_id=self.tree_id,
+            lft__gte=left,
+            lft__lte=right
         )
 
     def get_descendant_count(self):
         """
         Returns the number of descendants this model instance has.
         """
-        if self._mpttfield('right') is None:
-            # node not saved yet
-            return 0
-        else:
-            return (self._mpttfield('right') - self._mpttfield('left') - 1) // 2
+        return 0 if self.rght is None else (self.rght - self.lft - 1) // 2
 
     @raise_if_unsaved
     def get_leafnodes(self, include_self=False):
@@ -627,7 +619,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
 
         return self._tree_manager._mptt_filter(
             descendants,
-            left=(models.F(self._mptt_meta.right_attr) - 1)
+            lft=models.F('rght') - 1,
         )
 
     @raise_if_unsaved
@@ -641,13 +633,13 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
             qs = self._tree_manager._mptt_filter(
                 qs,
                 parent=None,
-                tree_id__gt=self._mpttfield('tree_id'),
+                tree_id__gt=self.tree_id,
             )
         else:
             qs = self._tree_manager._mptt_filter(
                 qs,
                 parent__pk=getattr(self, self._mptt_meta.parent_attr + '_id'),
-                left__gt=self._mpttfield('right'),
+                lft__gt=self.rght,
             )
 
         siblings = qs[:1]
@@ -665,16 +657,16 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
             qs = self._tree_manager._mptt_filter(
                 qs,
                 parent=None,
-                tree_id__lt=self._mpttfield('tree_id'),
+                tree_id__lt=self.tree_id,
             )
-            qs = qs.order_by('-' + opts.tree_id_attr)
+            qs = qs.order_by('-tree_id')
         else:
             qs = self._tree_manager._mptt_filter(
                 qs,
                 parent__pk=getattr(self, opts.parent_attr + '_id'),
-                right__lt=self._mpttfield('left'),
+                rght__lt=self.lft,
             )
-            qs = qs.order_by('-' + opts.right_attr)
+            qs = qs.order_by('-rght')
 
         siblings = qs[:1]
         return siblings and siblings[0] or None
@@ -688,7 +680,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
             return self
 
         return self._tree_manager._mptt_filter(
-            tree_id=self._mpttfield('tree_id'),
+            tree_id=self.tree_id,
             parent=None,
         ).get()
 
@@ -715,7 +707,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         """
         Returns the level of this node (distance from root)
         """
-        return getattr(self, self._mptt_meta.level_attr)
+        return self.level
 
     def insert_at(self, target, position='first-child', save=False,
                   allow_existing_pk=False, refresh_target=True):
@@ -755,20 +747,14 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         ``False`` otherwise.
         If include_self is True, also returns True if the two nodes are the same node.
         """
-        opts = self._mptt_meta
 
         if include_self and other.pk == self.pk:
             return True
 
-        if getattr(self, opts.tree_id_attr) != getattr(other, opts.tree_id_attr):
+        if self.tree_id != other.tree_id:
             return False
-        else:
-            left = getattr(self, opts.left_attr)
-            right = getattr(self, opts.right_attr)
 
-            return (
-                left > getattr(other, opts.left_attr) and
-                right < getattr(other, opts.right_attr))
+        return self.lft > other.lft and self.rght < other.rght
 
     @raise_if_unsaved
     def is_ancestor_of(self, other, include_self=False):
@@ -792,7 +778,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         self._tree_manager.move_node(self, target, position)
 
     def _is_saved(self, using=None):
-        if not self.pk or self._mpttfield('tree_id') is None:
+        if not self.pk or self.tree_id is None:
             return False
         opts = self._meta
         if remote_field(opts.pk) is None:
@@ -809,9 +795,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         from django.db.models.fields import AutoField
 
         field_names = []
-        internal_fields = (
-            self._mptt_meta.left_attr, self._mptt_meta.right_attr, self._mptt_meta.tree_id_attr,
-            self._mptt_meta.level_attr)
+        internal_fields = ('lft', 'rght', 'tree_id', 'level')
         for field in self._meta.fields:
             if (field.name not in internal_fields) and (not isinstance(field, AutoField)) and (not field.primary_key):  # noqa
                 field_names.append(field.name)
@@ -843,23 +827,22 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         if not (do_updates or track_updates):
             # inside manager.disable_mptt_updates(), don't do any updates.
             # unless we're also inside TreeManager.delay_mptt_updates()
-            if self._mpttfield('left') is None:
+            if self.lft is None:
                 # we need to set *some* values, though don't care too much what.
                 parent = getattr(self, '_%s_cache' % opts.parent_attr, None)
                 # if we have a cached parent, have a stab at getting
                 # possibly-correct values.  otherwise, meh.
                 if parent:
-                    left = parent._mpttfield('left') + 1
-                    setattr(self, opts.left_attr, left)
-                    setattr(self, opts.right_attr, left + 1)
-                    setattr(self, opts.level_attr, parent._mpttfield('level') + 1)
-                    setattr(self, opts.tree_id_attr, parent._mpttfield('tree_id'))
+                    self.lft = parent.lft + 1
+                    self.rght = parent.lft + 2
+                    self.level = parent.level + 1
+                    self.tree_id = parent.tree_id
                     self._tree_manager._post_insert_update_cached_parent_right(parent, 2)
                 else:
-                    setattr(self, opts.left_attr, 1)
-                    setattr(self, opts.right_attr, 2)
-                    setattr(self, opts.level_attr, 0)
-                    setattr(self, opts.tree_id_attr, 0)
+                    self.lft = 1
+                    self.rght = 2
+                    self.level = 0
+                    self.tree_id = 0
             return super(MPTTModel, self).save(*args, **kwargs)
 
         parent_id = opts.get_raw_field_value(self, opts.parent_attr)
@@ -887,18 +870,17 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
                         break
                 if not do_updates and not same_order:
                     same_order = True
-                    self.__class__._mptt_track_tree_modified(self._mpttfield('tree_id'))
+                    self.__class__._mptt_track_tree_modified(self.tree_id)
             elif (not do_updates) and not same_order and old_parent_id is None:
                 # the old tree no longer exists, so we need to collapse it.
-                collapse_old_tree = self._mpttfield('tree_id')
+                collapse_old_tree = self.tree_id
                 parent = getattr(self, opts.parent_attr)
-                tree_id = parent._mpttfield('tree_id')
-                left = parent._mpttfield('left') + 1
+                tree_id = parent.tree_id
                 self.__class__._mptt_track_tree_modified(tree_id)
-                setattr(self, opts.tree_id_attr, tree_id)
-                setattr(self, opts.left_attr, left)
-                setattr(self, opts.right_attr, left + 1)
-                setattr(self, opts.level_attr, parent._mpttfield('level') + 1)
+                self.tree_id = parent.tree_id
+                self.lft = parent.lft + 1
+                self.rght = parent.lft + 2
+                self.level = parent.level + 1
                 same_order = True
 
             if not same_order:
@@ -919,9 +901,9 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
                         # directly -- then we certainly do not have to update
                         # the cached parent.
                         update_cached_parent = parent and (
-                            getattr(self, opts.tree_id_attr) != getattr(parent, opts.tree_id_attr) or  # noqa
-                            getattr(self, opts.left_attr) < getattr(parent, opts.left_attr) or
-                            getattr(self, opts.right_attr) > getattr(parent, opts.right_attr))
+                            self.tree_id != parent.tree_id or
+                            self.lft < parent.lft or
+                            self.rght > parent.rght)
 
                     if right_sibling:
                         self._tree_manager._move_node(
@@ -933,7 +915,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
                             root_nodes = self._tree_manager.root_nodes()
                             try:
                                 rightmost_sibling = root_nodes.exclude(
-                                    pk=self.pk).order_by('-' + opts.tree_id_attr)[0]
+                                    pk=self.pk).order_by('-tree_id')[0]
                                 self._tree_manager._move_node(
                                     self, rightmost_sibling, 'right', save=False,
                                     refresh_target=False)
@@ -974,7 +956,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
 
         else:
             # new node, do an insert
-            if (getattr(self, opts.left_attr) and getattr(self, opts.right_attr)):
+            if self.lft and self.rght:
                 # This node has already been set up for insertion.
                 pass
             else:
@@ -1021,11 +1003,9 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         be passed directly to the django's ``Model.delete``.
 
         ``delete`` will not return anything. """
-        tree_width = (self._mpttfield('right') -
-                      self._mpttfield('left') + 1)
-        target_right = self._mpttfield('right')
-        tree_id = self._mpttfield('tree_id')
-        self._tree_manager._close_gap(tree_width, target_right, tree_id)
+        tree_width = self.rght - self.lft + 1
+        target_right = self.rght
+        self._tree_manager._close_gap(tree_width, target_right, self.tree_id)
         parent = getattr(self, '_%s_cache' % self._mptt_meta.parent_attr, None)
         if parent:
             right_shift = -self.get_descendant_count() - 2

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -1035,15 +1035,8 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
     delete.alters_data = True
 
     def _mptt_refresh(self):
-        if not self.pk:
-            return
-        manager = type(self)._tree_manager
-        opts = self._mptt_meta
-        values = manager.filter(pk=self.pk).values(
-            opts.left_attr,
-            opts.right_attr,
-            opts.level_attr,
-            opts.tree_id_attr,
-        )[0]
-        for k, v in values.items():
-            setattr(self, k, v)
+        self.refresh_from_db(fields=(
+            'tree_id', 'lft', 'rght', 'level', self._mptt_meta.parent_attr))
+        parent = getattr(self, self._mptt_meta.parent_attr)
+        self._mptt_cached_fields[self._mptt_meta.parent_attr] =\
+            parent.pk if parent else None

--- a/mptt/templatetags/mptt_admin.py
+++ b/mptt/templatetags/mptt_admin.py
@@ -158,10 +158,9 @@ def mptt_items_for_result(cl, result, form):
 
         # #### MPTT ADDITION START
         if field_name == mptt_indent_field:
-            level = getattr(result, result._mptt_meta.level_attr)
             padding_attr = mark_safe(' style="padding-%s:%spx"' % (
                 'right' if get_language_bidi() else 'left',
-                8 + mptt_level_indent * level))
+                8 + mptt_level_indent * result.level))
         else:
             padding_attr = ''
         # #### MPTT ADDITION END

--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -76,10 +76,9 @@ def tree_item_iterator(items, ancestors=False):
         if opts is None:
             opts = current._mptt_meta
 
-        current_level = getattr(current, opts.level_attr)
+        current_level = current.level
         if previous:
-            structure['new_level'] = (getattr(previous,
-                                              opts.level_attr) < current_level)
+            structure['new_level'] = previous.level < current_level
             if ancestors:
                 # If the previous node was the end of any number of
                 # levels, remove the appropriate number of ancestors
@@ -99,10 +98,7 @@ def tree_item_iterator(items, ancestors=False):
 
             first_item_level = current_level
         if next_:
-            structure['closed_levels'] = list(range(
-                current_level,
-                getattr(next_, opts.level_attr),
-                -1))
+            structure['closed_levels'] = list(range(current_level, next_.level, -1))
         else:
             # All remaining levels need to be closed
             structure['closed_levels'] = list(range(
@@ -161,16 +157,16 @@ def print_debug_info(qs, file=None):
     writer = csv.writer(sys.stdout if file is None else file)
     header = (
         'pk',
-        opts.level_attr,
+        'level',
         '%s_id' % opts.parent_attr,
-        opts.tree_id_attr,
-        opts.left_attr,
-        opts.right_attr,
+        'tree_id',
+        'lft',
+        'rght',
         'pretty',
     )
     writer.writerow(header)
     for n in qs.order_by('tree_id', 'lft'):
-        level = getattr(n, opts.level_attr)
+        level = n.level
         row = []
         for field in header[:-1]:
             row.append(getattr(n, field))

--- a/tests/myapp/doctests.txt
+++ b/tests/myapp/doctests.txt
@@ -7,8 +7,7 @@
 ...     opts = nodes[0]._mptt_meta
 ...     print('\n'.join(['%s %s %s %s %s %s' % \
 ...                      (n.pk, getattr(n, '%s_id' % opts.parent_attr) or '-',
-...                       getattr(n, opts.tree_id_attr), getattr(n, opts.level_attr),
-...                       getattr(n, opts.left_attr), getattr(n, opts.right_attr)) \
+...                       n.tree_id, n.level, n.lft, n.rght)\
 ...                      for n in nodes]))
 
 >>> def reset_sequence(model):

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -106,14 +106,6 @@ class Node(MPTTModel):
     parent = TreeForeignKey(
         'self', null=True, blank=True, related_name='children',
         on_delete=models.CASCADE)
-    # To check that you can set level_attr etc to an existing field.
-    level = models.IntegerField()
-
-    class MPTTMeta:
-        left_attr = 'does'
-        right_attr = 'zis'
-        level_attr = 'level'
-        tree_id_attr = 'work'
 
 
 class UUIDNode(MPTTModel):
@@ -145,15 +137,6 @@ class Tree(MPTTModel):
     parent = TreeForeignKey(
         'self', null=True, blank=True, related_name='children',
         on_delete=models.CASCADE)
-
-
-class NewStyleMPTTMeta(MPTTModel):
-    parent = TreeForeignKey(
-        'self', null=True, blank=True, related_name='children',
-        on_delete=models.CASCADE)
-
-    class MPTTMeta(object):
-        left_attr = 'testing'
 
 
 @python_2_unicode_compatible

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -468,7 +468,7 @@ class DeletionTestCase(TreeTestCase):
         self.assertTreeEqual(
             Category.objects.all(), """
             11 - 1 0 1 2
-            12 - 3 0 1 2
+            12 - 2 0 1 2
         """)
 
     def test_delete_last_node_with_siblings(self):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -60,3 +60,24 @@ ROOT_URLCONF = 'myapp.urls'
 
 # Swappable model testing
 MPTT_SWAPPABLE_MODEL = 'myapp.SwappedInModel'
+
+"""
+# NOTE! You'll also have to set DEBUG = True inside the testcases (either
+# in setUpClass or inside the test_* itself.)
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django.db.backends': {
+            'level': 'DEBUG',
+            'handlers': ['console'],
+        },
+    }
+}
+"""


### PR DESCRIPTION
This branch contains breaking changes, mostly rebased from #486.

# Goals

* Reduce the amount of magic in django-mptt
* Modernise the codebase
* Remove features that have a high maintenance burden for minimal utility

# Breaking changes

* `lft`/`rght`/`tree_id`/`level` attributes can no longer be renamed. This greatly simplifies the code.


# To do

* Go through the rest of #486 in detail, test each commit and PR them in
* Decide whether to keep `delay_mptt_updates` or not
* Whip up a deprecation release for the breaking changes, when this is looking more final
