### PR TITLE
Disallow parent_attr != 'parent'

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -276,10 +276,7 @@ class DraggableMPTTAdmin(MPTTModelAdmin):
         all_nodes = {}
 
         mptt_opts = self.model._mptt_meta
-        items = queryset.values_list(
-            'pk',
-            '%s_id' % mptt_opts.parent_attr,
-        )
+        items = queryset.values_list('pk', 'parent_id')
         for p_id, parent_id in items:
             all_nodes.setdefault(
                 str(parent_id) if parent_id else 0,

--- a/mptt/forms.py
+++ b/mptt/forms.py
@@ -161,7 +161,7 @@ class MPTTAdminForm(forms.ModelForm):
         if self.instance and self.instance.pk:
             instance = self.instance
             opts = self._meta.model._mptt_meta
-            parent_field = self.fields.get(opts.parent_attr)
+            parent_field = self.fields.get('parent')
             if parent_field:
                 parent_qs = parent_field.queryset
                 parent_qs = parent_qs.exclude(
@@ -174,11 +174,11 @@ class MPTTAdminForm(forms.ModelForm):
     def clean(self):
         cleaned_data = super(MPTTAdminForm, self).clean()
         opts = self._meta.model._mptt_meta
-        parent = cleaned_data.get(opts.parent_attr)
+        parent = cleaned_data.get('parent')
         if self.instance and parent:
             if parent.is_descendant_of(self.instance, include_self=True):
-                if opts.parent_attr not in self._errors:
-                    self._errors[opts.parent_attr] = self.error_class()
-                self._errors[opts.parent_attr].append(_('Invalid parent'))
-                del self.cleaned_data[opts.parent_attr]
+                if 'parent' not in self._errors:
+                    self._errors['parent'] = self.error_class()
+                self._errors['parent'].append(_('Invalid parent'))
+                del self.cleaned_data['parent']
         return cleaned_data

--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -158,7 +158,7 @@ def print_debug_info(qs, file=None):
     header = (
         'pk',
         'level',
-        '%s_id' % opts.parent_attr,
+        'parent_id',
         'tree_id',
         'lft',
         'rght',
@@ -226,7 +226,6 @@ def get_cached_trees(queryset):
 
     if queryset:
         # Get the model's parent-attribute name
-        parent_attr = queryset[0]._mptt_meta.parent_attr
         root_level = None
         for obj in queryset:
             # Get the current mptt node level
@@ -258,7 +257,7 @@ def get_cached_trees(queryset):
                 # Cache the parent on the current node, and attach the current
                 # node to the parent's list of children
                 _parent = current_path[-1]
-                setattr(obj, parent_attr, _parent)
+                obj.parent = _parent
                 _parent._cached_children.append(obj)
 
                 if root_level == 0:

--- a/tests/myapp/doctests.txt
+++ b/tests/myapp/doctests.txt
@@ -6,7 +6,7 @@
 >>> def print_tree_details(nodes):
 ...     opts = nodes[0]._mptt_meta
 ...     print('\n'.join(['%s %s %s %s %s %s' % \
-...                      (n.pk, getattr(n, '%s_id' % opts.parent_attr) or '-',
+...                      (n.pk, n.parent_id or '-',
 ...                       n.tree_id, n.level, n.lft, n.rght)\
 ...                      for n in nodes]))
 

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -53,7 +53,7 @@ def get_tree_details(nodes):
     return '\n'.join([
         '%s %s %s %s %s %s' % (
             n.pk,
-            getattr(n, '%s_id' % opts.parent_attr) or '-',
+            n.parent_id or '-',
             n.tree_id,
             n.level,
             n.lft,


### PR DESCRIPTION
Cherry-picked from bddbf4c5f5adb43813007cd75a473a65d7d22e84

With a bug fixed: 'parent' was included in the list of user fields, which broke field update tracking and caused a bunch of test failures. I haven't decided whether to remove field update tracking yet so I thought best to keep that working.

I renamed the method and added comments to be clearer about what it's doing there