### PR TITLE
Update admin.py

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -95,7 +95,7 @@ class MPTTModelAdmin(ModelAdmin):
 
     def get_actions(self, request):
         actions = super(MPTTModelAdmin, self).get_actions(request)
-        if 'delete_selected' in actions:
+        if actions is not None and 'delete_selected' in actions:
             actions['delete_selected'] = (
                 self.delete_selected_tree,
                 'delete_selected',


### PR DESCRIPTION
Hi, I was working with both django-mptt and django-admin-view-permission (https://github.com/ctxis/django-admin-view-permission/) and had trouble with "view only users": Their approach is to disable all actions to users whith this permissions, returning None in their get_actions method. (You can look at it here by the way get_actions  https://github.com/ctxis/django-admin-view-permission/blob/master/admin_view_permission/admin.py )
This approach is the one recommended by official django docs
https://docs.djangoproject.com/en/1.11/ref/contrib/admin/actions/#disabling-all-actions-for-a-particular-modeladmin

So, I guess it's better to handle both None objects or iterables as the expected value of calling super in get_actions( )
Greetings!