### PR TITLE
Disable index on all but tree_id_attr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: python
+cache: pip
+git:
+  depth: 1
 
 python:
   - "3.6"

--- a/tests/manage.py
+++ b/tests/manage.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+import os
+import sys
+
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -2362,14 +2362,26 @@ class NullableOrderedInsertion(TreeTestCase):
             2 1 1 1 2 3
             3 1 1 1 4 5
         """)
-        
 
-class ModelMeta(TreeTestCase):
+
+class ModelMetaIndexes(TreeTestCase):
+    def test_no_index_set(self):
+        class SomeModel(MPTTModel):
+            class Meta:
+                app_label = 'myapp'
+
+        tree_id_attr = getattr(SomeModel._mptt_meta, 'tree_id_attr')
+        self.assertTrue(SomeModel._meta.get_field(tree_id_attr).db_index)
+
+        for key in ('right_attr', 'left_attr', 'level_attr'):
+            field_name = getattr(SomeModel._mptt_meta, key)
+            self.assertFalse(SomeModel._meta.get_field(field_name).db_index)
+
     def test_index_together(self):
         already_idx = [['tree_id', 'lft'], ('tree_id', 'lft')]
         no_idx = [tuple(), list()]
         some_idx = [['tree_id'], ('tree_id',), [['tree_id']], (('tree_id',),)]
-        
+
         for idx, case in enumerate(already_idx + no_idx + some_idx):
             class Meta:
                 index_together = case


### PR DESCRIPTION
Ok. So, as far as I can tell, django-mptt always filters by `tree_id_attr` *first* in *any* query it does. Thus, adding an index on `right_attr`, `left_attr` and `level_attr` is a waste of time. By this I mean nobody is doing `SELECT * FROM table WHERE {right_attr|left_attr|level_attr} = X`. The predicate is *always* a `tree_id`. So, let's get rid of the individual indexes on these columns.

I've added `tree_id, left_attr` to index_together in #577, which this is based off, it should be simple to add any other attributes that are queried on together as part of that. But for now, getting rid of these is a good idea - the indexes are *not* used and are just an overhead for all inserts/updates.