### PR TITLE
Fix 576

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -1023,6 +1023,18 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
         be passed directly to the django's ``Model.delete``.
 
         ``delete`` will not return anything. """
+        try:
+            # We have to make sure we use database's mptt values, since they
+            # could have changed between the moment the instance was retrieved and
+            # the moment it is deleted.
+            # This happens for example if you delete several nodes at once from a queryset.
+            fields_to_refresh = [self._mptt_meta.right_attr,
+                                 self._mptt_meta.left_attr,
+                                 self._mptt_meta.tree_id_attr,]
+            self.refresh_from_db(fields=fields_to_refresh)
+        except self.__class__.DoesNotExist as e:
+            # In case the object was already deleted, we don't want to throw an exception
+            pass
         tree_width = (self._mpttfield('right') -
                       self._mpttfield('left') + 1)
         target_right = self._mpttfield('right')

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -528,6 +528,22 @@ class DeletionTestCase(TreeTestCase):
             10 8 1 2 11 12
         """)
 
+    def test_delete_multiple_nodes(self):
+        """Regression test for Issue 576."""
+        queryset = Category.objects.filter(id__in=[6,7])
+        for category in queryset:
+            category .delete()
+
+        self.assertTreeEqual(Category.objects.all(), """
+            1 - 1 0 1 16
+            2 1 1 1 2 7
+            3 2 1 2 3 4
+            4 2 1 2 5 6
+            5 1 1 1 8 9
+            8 1 1 1 10 15
+            9 8 1 2 11 12
+            10 8 1 2 13 14""")
+
 
 class IntraTreeMovementTestCase(TreeTestCase):
     pass


### PR DESCRIPTION
Fix & regression test for issue #576 

The drawback is that is makes one additional query for each deletion.
I think it is acceptable performance-wise as it only happens when the objects are already deleted by instance, which is usually used with a relatively low number of objects.
With higher number of objects, it is better to delete with the manager and rebuilding manually.



