### PR TITLE
Drop support for django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
 
 env:
   - DJANGO="Django>=1.8,<1.9"
-  - DJANGO="Django>=1.9,<1.10"
   - DJANGO="Django>=1.10,<1.11"
   - DJANGO="Django>=1.11,<2.0"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
@@ -19,8 +18,6 @@ matrix:
   exclude:
     - env: DJANGO="Django>=1.8,<1.9"
       python: "3.5"
-    - env: DJANGO="Django>=1.9,<1.10"
-      python: "3.3"
     - env: DJANGO="Django>=1.10,<1.11"
       python: "3.3"
     - env: DJANGO="Django>=1.11,<2.0"

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Requirements
 ------------
 
 * Python 2.7 or 3.3+
-* A supported version of Django (currently 1.8+)
+* A supported version of Django (currently 1.8, 1.10+)
 
 Feature overview
 ----------------

--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -154,7 +154,7 @@ to ``20``)::
     # ...
 
 
-.. _overriding admin templates: https://docs.djangoproject.com/en/1.9/ref/contrib/admin/#overriding-admin-templates
+.. _overriding admin templates: https://docs.djangoproject.com/en/1.11/ref/contrib/admin/#overriding-admin-templates
 .. _FeinCMS: https://github.com/feincms/feincms/
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     {py27,py33,py34,pypy}-{dj18}
-    {py27,py34,py35,pypy}-{dj19,dj110,dj111}
+    {py27,py34,py35,pypy}-{dj110,dj111}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -15,6 +15,5 @@ basepython =
 deps =
     mock_django>=0.6.7
     dj18: Django>=1.8,<1.9
-    dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<2.0


### PR DESCRIPTION
It reached its EOL in April 2017, see https://www.djangoproject.com/weblog/2017/apr/04/security-releases/