### PR TITLE
Don't access a tree after deleting it in delete_selected_tree()

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -80,10 +80,10 @@ class MPTTModelAdmin(ModelAdmin):
             with queryset.model._tree_manager.delay_mptt_updates():
                 for obj in queryset:
                     if self.has_delete_permission(request, obj):
-                        obj.delete()
-                        n += 1
                         obj_display = force_text(obj)
                         self.log_deletion(request, obj, obj_display)
+                        obj.delete()
+                        n += 1
             self.message_user(
                 request,
                 _('Successfully deleted %(count)d items.') % {'count': n})


### PR DESCRIPTION
Accessing an object after deleting it is not supported. E.g. the documentation
from log_deletion(): "Note that this method must be called before the deletion."
Doing so can create any type of exceptions, e.g. when calling \_\_str\_\_() for the
object. Fix that in delete_selected_tree().