### PR TITLE
Fix invalid escape sequences in string literals

### DIFF
--- a/mptt/fields.py
+++ b/mptt/fields.py
@@ -43,6 +43,6 @@ class TreeManyToManyField(models.ManyToManyField):
 # South integration
 if 'south' in settings.INSTALLED_APPS:  # pragma: no cover
     from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], ["^mptt\.fields\.TreeForeignKey"])
-    add_introspection_rules([], ["^mptt\.fields\.TreeOneToOneField"])
-    add_introspection_rules([], ["^mptt\.fields\.TreeManyToManyField"])
+    add_introspection_rules([], [r"^mptt\.fields\.TreeForeignKey"])
+    add_introspection_rules([], [r"^mptt\.fields\.TreeOneToOneField"])
+    add_introspection_rules([], [r"^mptt\.fields\.TreeManyToManyField"])


### PR DESCRIPTION
Starting with Python 3.6, invalid escape sequences in string literals are deprecated. When they exist, they produce a warning:

```
  DeprecationWarning: invalid escape sequence ...
```

For more information, see:

https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior

> A backslash-character pair that is not a valid escape sequence now generates a DeprecationWarning. Although this will eventually become a SyntaxError, that will not be for several Python releases.