### PR TITLE
Add support for depth in get_descendants and get_ancestors

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -538,7 +538,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
 
         if depth:
             if depth > 0:
-                qs = qs._mptt_filter(level__range=(self.level - depth, self.level))
+                qs = qs.filter(level__range=(self.level - depth, self.level))
             else:
                 raise ValueError('depth has to be larger than 0 or None. Got {}'.format(depth))
 
@@ -626,7 +626,7 @@ class MPTTModel(six.with_metaclass(MPTTModelBase, models.Model)):
 
         if depth:
             if depth > 0:
-                qs = qs._mptt_filter(level__range=(self.level, self.level + depth))
+                qs = qs.filter(level__range=(self.level, self.level + depth))
             else:
                 raise ValueError('depth has to be larger than 0 or None. Got %(depth)s' % {'depth': depth})
 


### PR DESCRIPTION
Sometimes, when `get_descendants` or `get_ancestors` are used, you want the results to only contain until a certain `level` and not the entire `QuerySet`. This pull request achieves that by adding a `depth` parameter to both functions