### PR TITLE
Update tutorial

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -110,9 +110,7 @@ Make a view
 This one's pretty simple for now. Add this lightweight view to your ``views.py``::
 
     def show_genres(request):
-        return render_to_response("genres.html",
-                              {'nodes':Genre.objects.all()},
-                              context_instance=RequestContext(request))
+        return render(request, "genres.html", {'nodes':Genre.objects.all()})
 
 And add a URL for it in ``urls.py``::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -114,7 +114,7 @@ This one's pretty simple for now. Add this lightweight view to your ``views.py``
 
 And add a URL for it in ``urls.py``::
 
-    (r'^genres/$', 'myapp.views.show_genres'),
+    (r'^genres/$', show_genres),
 
 Template
 --------
@@ -125,7 +125,7 @@ Create a template called ``genres.html`` in your template directory and put this
 
     {% load mptt_tags %}
     <ul>
-        {% recursetree nodes %}
+        {% recursetree genres %}
             <li>
                 {{ node.name }}
                 {% if not node.is_leaf_node %}

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -110,7 +110,7 @@ Make a view
 This one's pretty simple for now. Add this lightweight view to your ``views.py``::
 
     def show_genres(request):
-        return render(request, "genres.html", {'nodes':Genre.objects.all()})
+        return render(request, "genres.html", {'genres': Genre.objects.all()})
 
 And add a URL for it in ``urls.py``::
 


### PR DESCRIPTION
I updated tutorial file, because it was outdated.
The `context_instance parameter` in `render_to_response` was [deprecated in Django 1.8](https://docs.djangoproject.com/en/1.10/releases/1.8/#dictionary-and-context-instance-arguments-of-rendering-functions), and removed in Django 1.10.