### PR TITLE
Allow custom coercion function in tree_item_iterator

### DIFF
--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -36,7 +36,7 @@ def previous_current_next(items):
     return zip(prev, cur, nex)
 
 
-def tree_item_iterator(items, ancestors=False):
+def tree_item_iterator(items, ancestors=False, callback=text_type):
     """
     Given a list of tree items, iterates over the list, generating
     two-tuples of the current tree item and a ``dict`` containing
@@ -56,9 +56,9 @@ def tree_item_iterator(items, ancestors=False):
     available:
 
        ``'ancestors'``
-          A list of unicode representations of the ancestors of the
-          current node, in descending order (root node first, immediate
-          parent last).
+          A list of representations of the ancestors of the current
+          node, in descending order (root node first, immediate parent
+          last).
 
           For example: given the sample tree below, the contents of the
           list which would be available under the ``'ancestors'`` key
@@ -67,6 +67,10 @@ def tree_item_iterator(items, ancestors=False):
              Books                    ->  []
                 Sci-fi                ->  [u'Books']
                    Dystopian Futures  ->  [u'Books', u'Sci-fi']
+
+          You can overload the default representation by providing an
+          optional ``callback`` function which takes a single argument
+          and performs coersion as required.
 
     """
     structure = {}
@@ -90,7 +94,7 @@ def tree_item_iterator(items, ancestors=False):
                 # If the current node is the start of a new level, add its
                 # parent to the ancestors list.
                 if structure['new_level']:
-                    structure['ancestors'].append(text_type(previous))
+                    structure['ancestors'].append(callback(previous))
         else:
             structure['new_level'] = True
             if ancestors:

--- a/tests/myapp/doctests.txt
+++ b/tests/myapp/doctests.txt
@@ -89,6 +89,17 @@
 (<Genre: Action RPG>, True, [u'Role-playing Game'], [])
 (<Genre: Tactical RPG>, False, [u'Role-playing Game'], [1, 0])
 
+>>> for i,s in tree_item_iterator(Genre.objects.all(), ancestors=True, callback=lambda x: x):
+...     print((i, s['new_level'], s['ancestors'], list(s['closed_levels'])))
+(<Genre: Action>, True, [], [])
+(<Genre: Platformer>, True, [<Genre: Action>], [])
+(<Genre: 2D Platformer>, True, [<Genre: Action>, <Genre: Platformer>], [])
+(<Genre: 3D Platformer>, False, [<Genre: Action>, <Genre: Platformer>], [])
+(<Genre: 4D Platformer>, False, [<Genre: Action>, <Genre: Platformer>], [2, 1])
+(<Genre: Role-playing Game>, False, [], [])
+(<Genre: Action RPG>, True, [<Genre: Role-playing Game>], [])
+(<Genre: Tactical RPG>, False, [<Genre: Role-playing Game>], [1, 0])
+
 >>> action = Genre.objects.get(pk=action.pk)
 >>> [item.name for item in drilldown_tree_for_node(action)]
 [u'Action', u'Platformer']


### PR DESCRIPTION
The default implementation continues to return a string representation of the ancestors, however some use cases may wish to perform a different operation.

My personal use case was that I wanted the actual instances so I could access their methods and attributes as I iterated the tree.