### PR TITLE
Remove support for deprecated South

### DIFF
--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -2,6 +2,11 @@
 Upgrade notes
 =============
 
+UNRELEASED
+==========
+
+Removed South support. Projects should use Django builtin migrations instead.
+
 0.9.0
 =====
 

--- a/mptt/fields.py
+++ b/mptt/fields.py
@@ -38,11 +38,3 @@ class TreeManyToManyField(models.ManyToManyField):
     def formfield(self, **kwargs):
         kwargs.setdefault('form_class', TreeNodeMultipleChoiceField)
         return super(TreeManyToManyField, self).formfield(**kwargs)
-
-
-# South integration
-if 'south' in settings.INSTALLED_APPS:  # pragma: no cover
-    from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], [r"^mptt\.fields\.TreeForeignKey"])
-    add_introspection_rules([], [r"^mptt\.fields\.TreeOneToOneField"])
-    add_introspection_rules([], [r"^mptt\.fields\.TreeManyToManyField"])


### PR DESCRIPTION
South is no longer actively worked on. Django has supported migrations since 1.7. The feature is included in all supported Python versions.

From South documentation:

> This is the last major release of South, as migrations have been rolled into Django itself as part of the 1.7 release, and my efforts are now concentrated there. South will continue to receive security updates but no feature updates will be provided.