### PR TITLE
Remove unused argument from _inter_tree_move_and_close_gap()

### DIFF
--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -780,16 +780,11 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
 
     def _inter_tree_move_and_close_gap(
             self, node, level_change,
-            left_right_change, new_tree_id, parent_pk=None):
+            left_right_change, new_tree_id):
         """
         Removes ``node`` from its current tree, with the given set of
         changes being applied to ``node`` and its descendants, closing
         the gap left by moving ``node`` as it does so.
-
-        If ``parent_pk`` is ``None``, this indicates that ``node`` is
-        being moved to a brand new tree as its root node, and will thus
-        have its parent field set to ``NULL``. Otherwise, ``node`` will
-        have ``parent_pk`` set for its parent field.
         """
         connection = self._get_connection(instance=node)
         qn = connection.ops.quote_name
@@ -1026,10 +1021,8 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         # Make space for the subtree which will be moved
         self._create_space(tree_width, space_target, new_tree_id)
         # Move the subtree
-        connection = self._get_connection(instance=node)
         self._inter_tree_move_and_close_gap(
-            node, level_change, left_right_change, new_tree_id,
-            parent._meta.pk.get_db_prep_value(parent.pk, connection))
+            node, level_change, left_right_change, new_tree_id)
 
         # Update the node to be consistent with the updated
         # tree in the database.


### PR DESCRIPTION
The argument `parent_pk` has been unused by `TreeManager._inter_tree_move_and_close_gap()` since 3cc0bffc0f04e3333b86d43abd81dd0aaa086e0e.