### PR TITLE
Remove redundant tox.ini options that respecify defaults

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,6 @@ envlist =
 [testenv]
 changedir = {toxinidir}/tests
 commands = ./runtests.sh {posargs}
-basepython =
-    py27: python2.7
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-    pypy: pypy
 deps =
     mock_django>=0.6.7
     dj111: Django>=1.11,<2.0


### PR DESCRIPTION
There is no need to specify `basepython` in the `tox.ini` configuration. These values are defaults.

From https://tox.readthedocs.io/en/latest/config.html#factors-and-factor-conditional-settings

> tox provides good defaults for basepython setting, so the above  ini-file can be further reduced by omitting the basepython setting.

From https://tox.readthedocs.io/en/latest/example/general.html#basepython-defaults-overriding

> By default, for any pyXY test environment name the underlying "pythonX.Y" executable will be searched in your system PATH. It must exist in order to successfully create virtualenv environments.

Simplifies the configuration.