### PR TITLE
Update pypi.python.org URLs to pypi.org

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,7 +19,7 @@ named ``setup.py``. Enter this command::
 
 ...and the package will install automatically.
 
-.. _`PyPI`: https://pypi.python.org/pypi/django-mptt/
+.. _`PyPI`: https://pypi.org/project/django-mptt/
 .. _`pip`: https://pip.pypa.io/en/stable/
 
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html