### PR TITLE
Use builtin next(); available on all supported Pythons

### DIFF
--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -8,7 +8,7 @@ import csv
 import itertools
 import sys
 
-from django.utils.six import next, PY3, text_type
+from django.utils.six import PY3, text_type
 from django.utils.six.moves import zip
 from django.utils.translation import ugettext as _
 


### PR DESCRIPTION
No need to use a compatibility shim.