### PR TITLE
Changed default level indicator

### DIFF
--- a/mptt/settings.py
+++ b/mptt/settings.py
@@ -1,5 +1,5 @@
 from django.conf import settings
 
-"""Default level indicator. By default is `'---'`."""
+"""Default level indicator. By default is `'+--'`."""
 DEFAULT_LEVEL_INDICATOR = getattr(settings, 'MPTT_DEFAULT_LEVEL_INDICATOR',
-                                  '---')
+                                  '+--')


### PR DESCRIPTION
I've set new default level indicator.

The reason: it's not easy to understand what level it is by looking at line of minuses, for example

```
--- Category
------ Subcategory
```
vs
```
+-- Category
+--+-- Subcategory
```