### PR TITLE
Add Support for Django 2.1 and 2.2 as well as Python 3.7 and drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
-sudo: false
+dist: xenial
 language: python
 cache: pip
 git:
   depth: 1
 
 python:
+  - "3.7"
   - "3.6"
   - "3.5"
   - "2.7"
 
 env:
-  - DJANGO="Django>=1.11,<2.0"
+  - DJANGO="Django>=1.11.17,<2.0"
   - DJANGO="Django>=2.0,<2.1"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ git:
 python:
   - "3.6"
   - "3.5"
-  - "3.4"
   - "2.7"
 
 env:
@@ -21,8 +20,6 @@ matrix:
       python: "2.7"
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
       python: "2.7"
-    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
-      python: "3.4"
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
       python: "3.5"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
       python: "2.7"
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
       python: "3.4"
+    - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
+      python: "3.5"
   allow_failures:
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,17 @@ python:
 env:
   - DJANGO="Django>=1.11.17,<2.0"
   - DJANGO="Django>=2.0,<2.1"
+  - DJANGO="Django>=2.1,<2.2"
+  - DJANGO="Django>=2.2b1,<3.0"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 
 matrix:
   exclude:
     - env: DJANGO="Django>=2.0,<2.1"
+      python: "2.7"
+    - env: DJANGO="Django>=2.1,<2.2"
+      python: "2.7"
+    - env: DJANGO="Django>=2.2b1,<3.0"
       python: "2.7"
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
       python: "2.7"

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ structure and provides tools for working with trees of model instances.
 Requirements
 ------------
 
-* Python 2.7 or 3.4+
+* Python 2.7 or 3.5+
 * A supported version of Django (currently 1.11+)
 
 Feature overview

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         'Topic :: Utilities',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'Django>=1.11',
         'django-js-asset',
     ],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
@@ -34,7 +34,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    {py27,py34,py35,py36,pypy}-{dj111}
-    {py34,py35,py36}-{dj20}
+    {py27,py35,py36,pypy}-{dj111}
+    {py35,py36}-{dj20}
 
 [testenv]
 changedir = {toxinidir}/tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist =
-    {py27,py35,py36,pypy}-{dj111}
-    {py35,py36}-{dj20}
+    {py27,py35,py36,py37,pypy}-{dj111}
+    {py35,py36,py37}-{dj20}
 
 [testenv]
 changedir = {toxinidir}/tests
 commands = ./runtests.sh {posargs}
 deps =
     mock_django>=0.6.7
-    dj111: Django>=1.11,<2.0
+    dj111: Django>=1.11.17,<2.0
     dj20: Django>=2.0,<2.1

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist =
     {py27,py35,py36,py37,pypy}-{dj111}
     {py35,py36,py37}-{dj20}
+    {py35,py36,py37}-{dj21}
+    {py35,py36,py37}-{dj22}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -10,3 +12,5 @@ deps =
     mock_django>=0.6.7
     dj111: Django>=1.11.17,<2.0
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2b1,<3.0


### PR DESCRIPTION
Tests against Django master fail because Django 3.0 will no longer ship with `django.utils.six`.  The simplest solution would be to drop support for Python 2.7.  I'd happy to include this in this PR or a followup.