### PR TITLE
fix media ordering

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -154,6 +154,8 @@ class DraggableMPTTAdmin(MPTTModelAdmin):
                     'all': ['mptt/draggable-admin.css'],
                 },
                 js=[
+                    'admin/js/vendor/jquery/jquery.js',
+                    'admin/js/jquery.init.js',
                     JS('mptt/draggable-admin.js', {
                         'id': 'draggable-admin-context',
                         'data-context': json.dumps(


### PR DESCRIPTION
now for DraggableMPTTAdmin doesn't work js code
because `mptt/draggable-admin.js` loads before `admin/js/jquery.init.js`
and there is an error 

`Uncaught TypeError: Cannot read property 'fn' of undefined
    at draggable-admin.js:14`