### PR TITLE
Allow column sort in MPTTModelAdmin

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -41,6 +41,8 @@ class MPTTModelAdmin(ModelAdmin):
 
     form = MPTTAdminForm
 
+    mptt_change_list_sort = False  # enable sorting by column
+
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if issubclass(db_field.remote_field.model, MPTTModel) \
                 and not isinstance(db_field, TreeForeignKey) \
@@ -98,6 +100,11 @@ class MPTTModelAdmin(ModelAdmin):
                 'delete_selected',
                 _('Delete selected %(verbose_name_plural)s'))
         return actions
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = extra_context or dict()
+        extra_context['mptt_change_list_sort'] = self.mptt_change_list_sort
+        return super().changelist_view(request, extra_context=extra_context)
 
 
 class DraggableMPTTAdmin(MPTTModelAdmin):

--- a/mptt/templates/admin/mptt_change_list.html
+++ b/mptt/templates/admin/mptt_change_list.html
@@ -3,6 +3,6 @@
 
 {% block result_list %}
     {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
-    {% mptt_result_list cl %}
+    {% mptt_result_list cl mptt_change_list_sort %}
     {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
 {% endblock %}

--- a/mptt/templates/admin/mptt_change_list_results.html
+++ b/mptt/templates/admin/mptt_change_list_results.html
@@ -1,3 +1,4 @@
+{% load i18n static %}
 {% if result_hidden_fields %}
 <div class="hiddenfields">{# DIV for HTML validation #}
 {% for item in result_hidden_fields %}{{ item }}{% endfor %}
@@ -5,15 +6,28 @@
 {% endif %}
 {% if results %}
 <div class="results">
-<table cellspacing="0" id="result_list">
+{% if mptt_change_list_sort %}
+<span style="color: red; font-weight: bold; font-size: 0.7rem;">{% trans 'Attention: column sort will break tree ordering' %}</span>
+{% endif %}
+<table id="result_list">
 <thead>
 <tr>
-    {% for header in result_headers %}
-        <th scope="col"{{ header.class_attrib }}>
-            <div class="text"><span>{{ header.text|capfirst }}</span></div>
-            <div class="clear"></div>
-        </th>
-    {% endfor %}
+{% for header in result_headers %}
+<th scope="col" {{ header.class_attrib }}>
+    {% if mptt_change_list_sort and header.sortable %}
+        {% if header.sort_priority > 0 %}
+            <div class="sortoptions">
+                <a class="sortremove" href="{{ header.url_remove }}" title="{% trans "Remove from sorting" %}"></a>
+                {% if num_sorted_fields > 1 %}<span class="sortpriority" title="{% blocktrans with priority_number=header.sort_priority %}Sorting priority: {{ priority_number }}{% endblocktrans %}">{{ header.sort_priority }}</span>{% endif %}
+                <a href="{{ header.url_toggle }}" class="toggle {% if header.ascending %}ascending{% else %}descending{% endif %}" title="{% trans "Toggle sorting" %}"></a>
+            </div>
+        {% endif %}
+        <div class="text"><a href="{{ header.url_primary }}">{{ header.text|capfirst }}</a></div>
+    {% else %}
+    <div class="text"><span>{{ header.text|capfirst }}</span></div>
+    {% endif %}
+    <div class="clear"></div>
+</th>{% endfor %}
 </tr>
 </thead>
 <tbody>

--- a/mptt/templatetags/mptt_admin.py
+++ b/mptt/templatetags/mptt_admin.py
@@ -191,14 +191,15 @@ def mptt_results(cl):
             yield list(mptt_items_for_result(cl, res, None))
 
 
-def mptt_result_list(cl):
+def mptt_result_list(cl, mptt_change_list_sort=False):
     """
     Displays the headers and data list together
     """
     return {'cl': cl,
             'result_hidden_fields': list(result_hidden_fields(cl)),
             'result_headers': list(result_headers(cl)),
-            'results': list(mptt_results(cl))}
+            'results': list(mptt_results(cl)),
+            'mptt_change_list_sort': mptt_change_list_sort}
 
 
 # custom template is merely so we can strip out sortable-ness from the column headers


### PR DESCRIPTION
MPTT disables column sorting in django admin because it breaks the tree order. Still it would be nice to give the possibility to users to enable sorting if they want. In our case we needed to have sorting enabled so we made a few changes.

By default sorting is disabled but can be enalbed using
```mptt_change_list_sort = True```
in MPTTModelAdmin. A red message will appear above the change list results table, alerting the user that sorting by column will have consequences.