### PR TITLE
Removing deprecated functions for Django 3

### DIFF
--- a/mptt/admin.py
+++ b/mptt/admin.py
@@ -7,9 +7,9 @@ from django.contrib.admin.options import ModelAdmin, IncorrectLookupParameters, 
 from django.contrib.admin.models import LogEntry, CHANGE
 from django.contrib import messages
 from django.db import IntegrityError, transaction
-from django.utils.encoding import force_text, smart_text
+from django.utils.encoding import force_str, smart_str
 from django.utils.html import format_html, mark_safe
-from django.utils.translation import ugettext as _, ugettext_lazy
+from django.utils.translation import gettext as _, gettext_lazy
 from django.contrib.admin import RelatedFieldListFilter
 from django.contrib.admin.utils import get_model_from_relation
 from django.core.exceptions import ValidationError
@@ -77,7 +77,7 @@ class MPTTModelAdmin(ModelAdmin):
             with queryset.model._tree_manager.delay_mptt_updates():
                 for obj in queryset:
                     if self.has_delete_permission(request, obj):
-                        obj_display = force_text(obj)
+                        obj_display = force_str(obj)
                         self.log_deletion(request, obj, obj_display)
                         obj.delete()
                         n += 1
@@ -139,7 +139,7 @@ class DraggableMPTTAdmin(MPTTModelAdmin):
             item._mpttfield('level') * self.mptt_level_indent,
             item,
         )
-    indented_title.short_description = ugettext_lazy('title')
+    indented_title.short_description = gettext_lazy('title')
 
     def changelist_view(self, request, *args, **kwargs):
         if request.is_ajax() and request.POST.get('cmd') == 'move_node':
@@ -351,7 +351,7 @@ class TreeRelatedFieldListFilter(RelatedFieldListFilter):
         }
         for pk_val, val, padding_style in self.lookup_choices:
             yield {
-                'selected': self.lookup_val == smart_text(pk_val),
+                'selected': self.lookup_val == smart_str(pk_val),
                 'query_string': cl.get_query_string({
                     self.changed_lookup_kwarg: pk_val,
                 }, [self.lookup_kwarg_isnull]),

--- a/mptt/apps.py
+++ b/mptt/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class MpttConfig(AppConfig):

--- a/mptt/forms.py
+++ b/mptt/forms.py
@@ -3,9 +3,9 @@ Form components for working with trees.
 """
 from django import forms
 from django.forms.forms import NON_FIELD_ERRORS
-from django.utils.encoding import smart_text
+from django.utils.encoding import smart_str
 from django.utils.html import conditional_escape, mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from mptt.exceptions import InvalidMove
 from mptt.settings import DEFAULT_LEVEL_INDICATOR
@@ -40,7 +40,7 @@ class TreeNodeChoiceFieldMixin:
         generating option labels.
         """
         level_indicator = self._get_level_indicator(obj)
-        return mark_safe(level_indicator + ' ' + conditional_escape(smart_text(obj)))
+        return mark_safe(level_indicator + ' ' + conditional_escape(smart_str(obj)))
 
 
 class TreeNodeChoiceField(TreeNodeChoiceFieldMixin, forms.ModelChoiceField):

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -7,7 +7,7 @@ from itertools import groupby
 
 from django.db import models, connections, router
 from django.db.models import F, ManyToManyField, Max, Q
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from mptt.compat import cached_field_value
 from mptt.exceptions import CantDisableUpdates, InvalidMove

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -7,7 +7,7 @@ from django.db.models.base import ModelBase
 from django.db.models.query import Q
 from django.db.models.query_utils import DeferredAttribute
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from mptt.compat import cached_field_value
 from mptt.fields import TreeForeignKey, TreeOneToOneField, TreeManyToManyField

--- a/mptt/templatetags/mptt_admin.py
+++ b/mptt/templatetags/mptt_admin.py
@@ -15,7 +15,7 @@ try:
     from django.utils.deprecation import RemovedInDjango20Warning
 except ImportError:
     RemovedInDjango20Warning = RuntimeWarning
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language_bidi
@@ -112,7 +112,7 @@ def mptt_items_for_result(cl, result, form):
                     # #### MPTT SUBSTITUTION END
                 if isinstance(f, (models.DateField, models.TimeField, models.ForeignKey)):
                     row_classes.append('nowrap')
-        if force_text(result_repr) == '':
+        if force_str(result_repr) == '':
             result_repr = mark_safe('&nbsp;')
         row_class = mark_safe(' class="%s"' % ' '.join(row_classes))
 
@@ -174,12 +174,12 @@ def mptt_items_for_result(cl, result, form):
                     field_name == cl.model._meta.pk.name and
                     form[cl.model._meta.pk.name].is_hidden)):
                 bf = form[field_name]
-                result_repr = mark_safe(force_text(bf.errors) + force_text(bf))
+                result_repr = mark_safe(force_str(bf.errors) + force_str(bf))
             # #### MPTT SUBSTITUTION START
             yield format_html('<td{}{}>{}</td>', row_class, padding_attr, result_repr)
             # #### MPTT SUBSTITUTION END
     if form and not form[cl.model._meta.pk.name].is_hidden:
-        yield format_html('<td>{}</td>', force_text(form[cl.model._meta.pk.name]))
+        yield format_html('<td>{}</td>', force_str(form[cl.model._meta.pk.name]))
 
 
 def mptt_results(cl):

--- a/mptt/templatetags/mptt_tags.py
+++ b/mptt/templatetags/mptt_tags.py
@@ -5,9 +5,9 @@ trees.
 from django import template
 from django.apps import apps
 from django.core.exceptions import FieldDoesNotExist
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 from mptt.utils import (drilldown_tree_for_node, get_cached_trees,
                         tree_item_iterator)
@@ -232,7 +232,7 @@ def tree_path(items, separator=' :: '):
        {{ some_node.get_ancestors|tree_path:" > " }}
 
     """
-    return separator.join(force_text(i) for i in items)
+    return separator.join(force_str(i) for i in items)
 
 
 # ## RECURSIVE TAGS

--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -7,7 +7,7 @@ import csv
 import itertools
 import sys
 
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 __all__ = ('previous_current_next', 'tree_item_iterator',
            'drilldown_tree_for_node', 'get_cached_trees',)


### PR DESCRIPTION
Since support for Python 2 was dropped (https://github.com/django-mptt/django-mptt/pull/691) and Django 3 has deprecated the various legacy unicode string functions (https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0), I just replaced the following:

* `ugettext_` -> `gettext_`
* `force_text` -> `force_str`
* `smart_text` -> `smart_str`