### PR TITLE
Add Django 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - DJANGO="Django==2.0.*"
   - DJANGO="Django==2.1.*"
   - DJANGO="Django==2.2.*"
+  - DJANGO="Django==3.0.*"
   - DJANGO="https://github.com/django/django/archive/master.tar.gz"
 
 matrix:
@@ -25,6 +26,8 @@ matrix:
       python: "3.8"
     - env: DJANGO="Django==2.1.*"
       python: "3.8"
+    - env: DJANGO="Django==3.0.*"
+      python: "3.5"
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
       python: "3.5"
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ git:
   depth: 1
 
 python:
+  - "3.8"
   - "3.7"
   - "3.6"
   - "3.5"
@@ -18,6 +19,12 @@ env:
 
 matrix:
   exclude:
+    - env: DJANGO="Django==1.11.*"
+      python: "3.8"
+    - env: DJANGO="Django==2.0.*"
+      python: "3.8"
+    - env: DJANGO="Django==2.1.*"
+      python: "3.8"
     - env: DJANGO="https://github.com/django/django/archive/master.tar.gz"
       python: "3.5"
   allow_failures:

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -910,15 +910,14 @@ class MPTTModel(models.Model, metaclass=MPTTModelBase):
                 same_order = True
 
             if not same_order:
+                parent = getattr(self, opts.parent_attr)
                 opts.set_raw_field_value(self, opts.parent_attr, old_parent_id)
                 try:
                     right_sibling = None
                     if opts.order_insertion_by:
-                        right_sibling = opts.get_ordered_insertion_target(
-                            self, getattr(self, opts.parent_attr))
+                        right_sibling = opts.get_ordered_insertion_target(self, parent)
 
                     if parent_id is not None:
-                        parent = getattr(self, opts.parent_attr)
                         # If we aren't already a descendant of the new parent,
                         # we need to update the parent.rght so things like
                         # get_children and get_descendant_count work correctly.

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
+        'Framework :: Django :: 3.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         'Topic :: Utilities',

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -1652,7 +1652,7 @@ class AdminBatch(TreeTestCase):
             '_selected_action': ['5', '8', '9'],
         }
         response = self.client.post('/admin/myapp/category/', data)
-        self.assertContains(response, 'value="Yes, I\'m sure"', 1)
+        self.assertRegex(response.rendered_content, r'value="Yes, I(\'|’)m sure"')
 
         data['post'] = 'yes'
         response = self.client.post('/admin/myapp/category/', data)

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     {py35,py36,py37}-{dj20}
     {py35,py36,py37}-{dj21}
     {py35,py36,py37,py38}-{dj22}
+    {py36,py37,py38}-{dj30}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -14,3 +15,4 @@ deps =
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<3.0
+    dj30: Django>=3.0,<3.1

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     {py35,py36,py37,pypy}-{dj111}
     {py35,py36,py37}-{dj20}
     {py35,py36,py37}-{dj21}
-    {py35,py36,py37}-{dj22}
+    {py35,py36,py37,py38}-{dj22}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -13,4 +13,4 @@ deps =
     dj111: Django>=1.11.17,<2.0
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
-    dj22: Django>=2.2b1,<3.0
+    dj22: Django>=2.2,<3.0


### PR DESCRIPTION
#721

Following django/django@4122d9d, this changes the model `save()` logic to get `self.parent` before (rather than after) it temporarily sets `self.parent_id` to the old parent ID.

I'm not particularly confident of the fix, since I'm not sure how it was guaranteed that `self.parent` and `self.parent_id` are consistent prior to django/django@4122d9d.

Nonetheless, this gets tests passing, so if there are problems with this approach I think additional tests should be added.

(Additionally, I updated the test matrix for Python 3.8: https://docs.djangoproject.com/en/3.0/faq/install/#what-python-version-can-i-use-with-django.)