### PR TITLE
docs: Fix simple typo, neccessary -> necessary

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -461,7 +461,7 @@ Returns the root node of tree with the given id.
 Sets up the tree state for ``node`` (which has not yet been inserted
 into in the database) so it will be positioned relative to a given
 ``target`` node as specified by ``position`` (when appropriate) when it
-is inserted, with any neccessary space already having been made for it.
+is inserted, with any necessary space already having been made for it.
 
 A ``target`` of ``None`` indicates that ``node`` should be the last root
 node.

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -440,7 +440,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         Sets up the tree state for ``node`` (which has not yet been
         inserted into in the database) so it will be positioned relative
         to a given ``target`` node as specified by ``position`` (when
-        appropriate) it is inserted, with any neccessary space already
+        appropriate) it is inserted, with any necessary space already
         having been made for it.
 
         A ``target`` of ``None`` indicates that ``node`` should be

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -828,7 +828,7 @@ class MPTTModel(models.Model, metaclass=MPTTModelBase):
     def save(self, *args, **kwargs):
         """
         If this is a new node, sets tree fields up before it is inserted
-        into the database, making room in the tree structure as neccessary,
+        into the database, making room in the tree structure as necessary,
         defaulting to making the new node the last child of its parent.
 
         It the node's left and right edge indicators already been set, we


### PR DESCRIPTION
There is a small typo in docs/models.rst, mptt/managers.py, mptt/models.py.

Should read `necessary` rather than `neccessary`.

