### PR TITLE
Removed unused import

### DIFF
--- a/mptt/fields.py
+++ b/mptt/fields.py
@@ -2,7 +2,6 @@
 Model fields for working with trees.
 """
 from django.db import models
-from django.conf import settings
 from mptt.forms import TreeNodeChoiceField, TreeNodeMultipleChoiceField
 
 


### PR DESCRIPTION
I couldn't fully understand if there is a real reason to be 
```from django.conf import settings```
at fifth line? I just was browsing sources of my project and accidentally encounter on this module and my editor introspector didn't show me any usage of this across the file.
Sorry if i'm mistaken.