### PR TITLE
Allow to use TreeQuerySet as manager method to get TreeManager class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ MANIFEST
 tests/mydatabase
 *.egg
 .eggs
+venv/
+.idea/

--- a/mptt/querysets.py
+++ b/mptt/querysets.py
@@ -4,6 +4,15 @@ from mptt import utils
 
 
 class TreeQuerySet(models.query.QuerySet):
+    def as_manager(cls):
+        # Address the circular dependency between `Queryset` and `Manager`.
+        from mptt.managers import TreeManager
+        manager = TreeManager.from_queryset(cls)()
+        manager._built_with_as_manager = True
+        return manager
+    as_manager.queryset_only = True
+    as_manager = classmethod(as_manager)
+
     def get_descendants(self, *args, **kwargs):
         """
         Alias to `mptt.managers.TreeManager.get_queryset_descendants`.

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -14,6 +14,7 @@ from django.test import RequestFactory, TestCase
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.admin import ModelAdmin, site
 from mptt.admin import TreeRelatedFieldListFilter
+from mptt.querysets import TreeQuerySet
 
 try:
     from mock_django import mock_signal_receiver
@@ -1730,6 +1731,11 @@ class QuerySetTests(TreeTestCase):
             [
                 c.pk for c in
                 Category.objects.filter(name="Nintendo Wii").get_descendants(include_self=True)],
+        )
+
+    def test_as_manager(self):
+        self.assertTrue(
+            issubclass(TreeQuerySet.as_manager().__class__, TreeManager)
         )
 
 


### PR DESCRIPTION
This pull request allows users to write something like:

```
class MyModel(MPTTModel):
    objects = MyTreeQuerySet.as_manager()
```


instead of:
```
class MyModel(MPTTModel):
    objects = TreeManager.from_queryset(MyTreeQuerySet)()
```

`objects` will be instance of TreeManager instead of standard django manager.  
It means, users will be able to use TreeManager methods in `objects`.  
