### PR TITLE
Remove providing_args argument is signals

### DIFF
--- a/mptt/signals.py
+++ b/mptt/signals.py
@@ -5,8 +5,4 @@ from django.db.models.signals import ModelSignal
 # ``move_to``.
 # If the signal is called from ``save`` it'll not be pass position.
 
-node_moved = ModelSignal(providing_args=[
-    'instance',
-    'target',
-    'position'
-])
+node_moved = ModelSignal()


### PR DESCRIPTION
> django.utils.deprecation.RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.