### PR TITLE
Use_state.adding in raise_if_unsaved

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -387,7 +387,7 @@ class MPTTModelBase(ModelBase):
 def raise_if_unsaved(func):
     @wraps(func)
     def _fn(self, *args, **kwargs):
-        if not self.pk:
+        if self._state.adding:
             raise ValueError(
                 'Cannot call %(function)s on unsaved %(class)s instances'
                 % {'function': func.__name__, 'class': self.__class__.__name__}


### PR DESCRIPTION
In order to check if an instance is unsaved in the decorator `raise_if_unsaved` we should use `_state.adding`. Current `not self.pk 
` is raising problems for custom primary keys.

https://docs.djangoproject.com/en/3.1/ref/models/instances/

PD: don't know if using `_is_saved` is a better idea to handle this logic in only one place