### PR TITLE
Set pre version, to make installing git version over latest releae possible

### DIFF
--- a/mptt/__init__.py
+++ b/mptt/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.0"
+__version__ = "0.12.0-pre"
 VERSION = tuple(__version__.split("."))
 
 default_app_config = "mptt.apps.MpttConfig"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.11.0
+current_version = 0.12.0-pre
 commit = True
 tag = True
 tag_name = {new_version}

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
         "Utilities for implementing Modified Preorder Tree Traversal "
         "with your Django Models and working with trees of Model instances."
     ),
-    version="0.11.0",
+    version="0.12.0-pre",
     author="Craig de Stigter",
     author_email="craig.ds@gmail.com",
     url="https://github.com/django-mptt/django-mptt",


### PR DESCRIPTION
With the current state of master, when first installing via `pip install django-mptt` and then trying to upgrade to git master by installing via `pip install 'git+https://github.com/django-mptt/django-mptt.git'` pip thinks the version is the same (0.11.0) and therefore doesn't actually install the newer code.

This PR fixes that by making master a `-pre` version. The idea is that when releasing 0.12.0, the `-pre` is removed in the release branch and master can then be bumped to `0.13.0-pre`.