### PR TITLE
Add support for django __ syntax to add_related_count rel_field

### DIFF
--- a/tests/myapp/fixtures/items.json
+++ b/tests/myapp/fixtures/items.json
@@ -16,5 +16,14 @@
             "category_fk": "b6299e26-d5e9-4dc2-9e2a-3f8033c8dfe5",
             "category_pk": 5
         }
+    },
+    {
+      "pk": 3,
+      "model": "myapp.item",
+      "fields": {
+        "name": "toplevel item",
+        "category_fk": "6263ac21-f08b-4b44-9462-0489c56e0d3d",
+        "category_pk": 1
+      }
     }
 ]

--- a/tests/myapp/fixtures/subitems.json
+++ b/tests/myapp/fixtures/subitems.json
@@ -1,0 +1,16 @@
+[
+  {
+    "pk": 1,
+    "model": "myapp.subitem",
+    "fields": {
+      "item": 1
+    }
+  },
+  {
+    "pk": 2,
+    "model": "myapp.subitem",
+    "fields": {
+      "item": 3
+    }
+  }
+]

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -54,6 +54,10 @@ class Item(models.Model):
         return self.name
 
 
+class SubItem(models.Model):
+    item = models.ForeignKey(Item, null=True, on_delete=models.CASCADE)
+
+
 class Genre(MPTTModel):
     name = models.CharField(max_length=50, unique=True)
     parent = TreeForeignKey(


### PR DESCRIPTION
This PR adds support for `__` syntax to the rel_field argument of the add_related_count method. 

The rationale is that sometimes you might want to count objects that are a multistep relation away from the mptt model. I've added a model to the testsuite (`SubItem`) and associated tests to showcase the idea and test the implementation.