### PR TITLE
Fix RemovedInDjango41Warning

### DIFF
--- a/mptt/__init__.py
+++ b/mptt/__init__.py
@@ -1,7 +1,10 @@
+import django
+
 __version__ = "0.12.0"
 VERSION = tuple(__version__.split("."))
 
-default_app_config = "mptt.apps.MpttConfig"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "mptt.apps.MpttConfig"
 
 
 def register(*args, **kwargs):


### PR DESCRIPTION
RemovedInDjango41Warning: 'mptt' defines default_app_config = 'mptt.apps.MpttConfig'. Django now detects this configuration automatically. You can remove default_app_config.RemovedInDjango41Warning: 'mptt' defines default_app_config = 'mptt.apps.MpttConfig'. Django now detects this configuration automatically. You can remove default_app_config.