### PR TITLE
Do not install tests.myapp

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ tests =
 [options.packages.find]
 exclude =
     tests
-    myapp
+    tests.*
 
 [flake8]
 exclude = venv,.tox,build,docs


### PR DESCRIPTION
Fix options.packages.find.exclude to cover subpackages of "tests"
recursively.  Otherwise, tests.myapp is installed.