### PR TITLE
Use default django css variables

### DIFF
--- a/mptt/static/mptt/draggable-admin.css
+++ b/mptt/static/mptt/draggable-admin.css
@@ -20,7 +20,7 @@
 
 /* focus */
 #result_list tbody tr:focus {
-  background-color: #ffffcc !important; outline: 0px; }
+  background-color: var(--selected-row, #ffc) !important; outline: 0px; }
 
 @media (prefers-color-scheme: dark) {
   .tree-node.children { background-image: url(disclosure-down-white.png); }
@@ -28,7 +28,7 @@
   .drag-handle { background-image: url(arrow-move-white.png); }
 
   #result_list tbody tr:focus {
-    background-color: #002f33 !important; outline: 0px; }
+    background-color: var(--selected-row, #00363A) !important; outline: 0px; }
 }
 
 #drag-line {


### PR DESCRIPTION
As discussed in #797. Uses the default django admin theme css variables with fallbacks for older django versions.
The fallbacks values are taken from:
https://github.com/django/django/blob/main/django/contrib/admin/static/admin/css/base.css 