### PR TITLE
Fix light theme asset path

### DIFF
--- a/mptt/static/mptt/draggable-admin.css
+++ b/mptt/static/mptt/draggable-admin.css
@@ -13,10 +13,10 @@
 }
 
 .tree-node { cursor: pointer; }
-.tree-node.children { background-image: url(disclosure-down.png); }
-.tree-node.closed { background-image: url(disclosure-right.png); }
+.tree-node.children { background-image: url(disclosure-down-black.png); }
+.tree-node.closed { background-image: url(disclosure-right-black.png); }
 
-.drag-handle { background-image: url(arrow-move.png); cursor: move; }
+.drag-handle { background-image: url(arrow-move-black.png); cursor: move; }
 
 /* focus */
 #result_list tbody tr:focus {


### PR DESCRIPTION
Fixes the problems with the light themes discussed in #797. The file pathes were wrong. Tested in Safari and Firefox.