### PR TITLE
BUGFIX: Cannot call get_descendants on unsaved models using PostgreSQ…

### DIFF
--- a/mptt/__init__.py
+++ b/mptt/__init__.py
@@ -1,7 +1,7 @@
 import django
 
 
-__version__ = "0.13.3"
+__version__ = "0.13.4"
 VERSION = tuple(__version__.split("."))
 
 if django.VERSION < (3, 2):  # pragma: no cover

--- a/mptt/forms.py
+++ b/mptt/forms.py
@@ -174,7 +174,7 @@ class MPTTAdminForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.instance and self.instance.pk:
+        if self.instance and self.instance.pk and not self.instance._state.adding:
             instance = self.instance
             opts = self._meta.model._mptt_meta
             parent_field = self.fields.get(opts.parent_attr)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-mptt
-version = 0.13.3
+version = 0.13.4
 description = Utilities for implementing Modified Preorder Tree Traversal with your Django Models and working with trees of Model instances.
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
__BUGFIX__:  Cannot call get_descendants on unsaved models using PostgreSQL databases when adding new models through Django Admin.

A UUID primary key field using a PostgreSQL database will always have a value regardless of the model being saved or not.
Therefore is is necessary to add an additional check "__and not self.instance._state.adding__"  to the init function to make sure there is no ValueError when adding new models using the Django Admin interface.

```python
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)
        if self.instance and self.instance.pk and not self.instance._state.adding:
            instance = self.instance
            opts = self._meta.model._mptt_meta
            parent_field = self.fields.get(opts.parent_attr)
            if parent_field:
                parent_qs = parent_field.queryset
                parent_qs = parent_qs.exclude(
                    pk__in=instance.get_descendants(include_self=True).values_list(
                        "pk", flat=True
                    )
                )
                parent_field.queryset = parent_qs
```
