### PR TITLE
Raise exception when usage through model_mommy/model_bakery is not explicitly indicated

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Topic docs:
    utilities
    changelog
    technical_details
+   testing
 
 .. toctree::
    :maxdepth: 3

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,24 @@
+===================
+Testing MPTT models
+===================
+
+
+Using testing generators
+========================
+
+Using testing generators such as ``model_mommy`` or ``model_bakery`` is causing random tree fields values, which can cause unexpected behavior.
+To prevent that the ``django-mptt.MPTTModel`` will throw an Exception if made throught model_mommy/model_bakery in test environment unless
+the ``MPTT_ALLOW_TESTING_GENERATORS`` setting is set to True.
+
+You can set the ``MPTT_ALLOW_TESTING_GENERATORS`` setting to True in your Django testing settings.py file or by the ``@override_settings`` decorator for particular test.
+You would probably also have to use recipe and explicitly set the appropriate fields for the model.
+
+.. code-block:: python
+
+    from django.test import override_settings
+    from baker.recipe import Recipe
+
+    @override_settings(MPTT_ALLOW_TESTING_GENERATORS=True)
+    def test_mptt_allow_testing_generators(self):
+        my_model_recipe = Recipe(MyMPTTModel, lft=None, rght=None)
+        test_model_instance = my_model_recipe.make()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,5 @@ mock-django
 Django >= 2.2
 coverage
 django-js-asset
+model-bakery
+model-mommy

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ deps =
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz
+    model-bakery
+    model-mommy
 
 [testenv:style]
 deps =


### PR DESCRIPTION
Fix #694 by not allowing usage through `model_mommy`/`model_bakery` unless explicitly indicated by `MPTT_ALLOW_TESTING_GENERATORS` settings.
