### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -403,7 +403,7 @@ model.
    descendants, otherwise it will be for each item itself.
 
 ``extra_filters``
-   Dict with aditional parameters filtering the related queryset.
+   Dict with additional parameters filtering the related queryset.
 
 
 Example usage in the admin

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -7,7 +7,7 @@ Using testing generators
 ========================
 
 Using testing generators such as ``model_mommy`` or ``model_bakery`` is causing random tree fields values, which can cause unexpected behavior.
-To prevent that the ``django-mptt.MPTTModel`` will throw an Exception if made throught model_mommy/model_bakery in test environment unless
+To prevent that the ``django-mptt.MPTTModel`` will throw an Exception if made through model_mommy/model_bakery in test environment unless
 the ``MPTT_ALLOW_TESTING_GENERATORS`` setting is set to True.
 
 You can set the ``MPTT_ALLOW_TESTING_GENERATORS`` setting to True in your Django testing settings.py file or by the ``@override_settings`` decorator for particular test.

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -192,7 +192,7 @@ class MPTTOptions:
                 value = field.pre_save(instance, True)
 
             if value is None:
-                # we have to use __isnull instead of __lt or __gt becase __lt = Null is invalid
+                # we have to use __isnull instead of __lt or __gt because __lt = Null is invalid
                 # depending on order, we need to find the first node where code is null or not null
                 value = filter_suffix == "__lt"
                 filter_suffix = "__isnull"

--- a/mptt/utils.py
+++ b/mptt/utils.py
@@ -72,7 +72,7 @@ def tree_item_iterator(items, ancestors=False, callback=str):
 
           You can overload the default representation by providing an
           optional ``callback`` function which takes a single argument
-          and performs coersion as required.
+          and performs coercion as required.
 
     """
     structure = {}


### PR DESCRIPTION
There are small typos in:
- docs/models.rst
- docs/testing.rst
- mptt/models.py
- mptt/utils.py

Fixes:
- Should read `through` rather than `throught`.
- Should read `coercion` rather than `coersion`.
- Should read `because` rather than `becase`.
- Should read `additional` rather than `aditional`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md