### PR TITLE
Update mptt_change_list.html to include {% change_list_object_tools %}

### DIFF
--- a/mptt/templates/admin/mptt_change_list.html
+++ b/mptt/templates/admin/mptt_change_list.html
@@ -2,7 +2,26 @@
 {% load admin_list i18n mptt_admin %}
 
 {% block result_list %}
-    {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+  <div class="row">
+    <div class="col-12 col-sm-8">
+      {% if action_form and actions_on_top and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+    </div>
+    <div class="col-12 col-sm-4">
+      {% block object-tools %}
+        {% block object-tools-items %}
+          {% change_list_object_tools %}
+        {% endblock %}
+      {% endblock %}
+    </div>
+    <hr>
+    <div class="col-12">
     {% mptt_result_list cl %}
-    {% if action_form and actions_on_bottom and cl.show_admin_actions %}{% admin_actions %}{% endif %}
+    </div>
+    {% if action_form and actions_on_bottom and cl.show_admin_actions %}
+      <div class="row">
+        <div class="col-12">
+          {% admin_actions %}
+        </div>
+      </div>{% endif %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
It seems that the admin template admin/mptt-change-list.html currently does not have the {% change_list_object_tools %} tag present, which causes the Add button to not be rendered. This change ensures that the Add button is rendered even when the django admin has some kind of skin added to it (eg. jazzmin). 

https://stackoverflow.com/questions/68722249/django-jazzmin-add-button-disappeared-after-adding-mptt-admin/69230357#69230357