### PR TITLE
Point out unclear maintenance of django-treebeard

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 Alternatives to django-mptt include:
 
 * `django-treebeard <https://pypi.org/project/django-treebeard/>`_ includes a MPTT
-  implementation (called nested set)
+  implementation (called nested set), but the state of maintenance is unclear.
 * Maybe you do not need MPTT, especially when using newer databases. See
   `django-tree-queries <https://github.com/matthiask/django-tree-queries>`_ for an
   implementation using recursive Common Table Expressions (CTE). See the


### PR DESCRIPTION
I migrated my project from django-mptt to django-treebeard because of the "unmaintained" warning in the README and the alongside recommendations.

Ironically, treebeard seems kind of dead (the [last release](https://pypi.org/project/django-treebeard/#history) was 1,5y ago, [my PR](https://github.com/django-treebeard/django-treebeard/pull/245) has been waiting for a review for 8 months) and there has been some progress in this repo instead.

So to prevent others from making the same mistake I made, I would point out that migrating the tree library does not necessarily improve the maintenance.