### PR TITLE
Add support for django 4.2

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -47,6 +47,7 @@ To change the names, create an ``MPTTMeta`` class inside your class::
         class MPTTMeta:
             level_attr = 'mptt_level'
             order_insertion_by=['name']
+            indexes = [Index(fields=["tree_id", "lft", "rght"])]
 
 The available options for the MPTTMeta class are:
 
@@ -111,6 +112,13 @@ exist, they will be added to the model dynamically:
       or other updates, where ``django-mptt`` will need to re-order the
       tree you will most likely be left with dangling references.
       Please see :ref:`order_insertion_by_gotcha` for details.
+
+``indexes``
+   A list of django 
+   `Index <https://docs.djangoproject.com/en/4.2/ref/models/indexes/#index-options>`_ 
+   objects, to configure custom indexes for mptt specific fields, cause they will not 
+   be available on the django model check routines.
+  
 
 Registration of existing models
 ===============================

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -15,7 +15,7 @@ from mptt.compat import cached_field_value
 from mptt.fields import TreeForeignKey, TreeManyToManyField, TreeOneToOneField
 from mptt.managers import TreeManager
 from mptt.signals import node_moved
-from mptt.utils import _get_tree_model
+from mptt.utils import _get_tree_model, append_indexes
 
 
 __all__ = (
@@ -72,6 +72,7 @@ class MPTTOptions:
     tree_id_attr = "tree_id"
     level_attr = "level"
     parent_attr = "parent"
+    indexes = []
 
     def __init__(self, opts=None, **kwargs):
         # Override defaults with options provided
@@ -375,9 +376,7 @@ class MPTTModelBase(ModelBase):
 
                 # Add an index_together on tree_id_attr and left_attr, as these are very
                 # commonly queried (pretty much all reads).
-                index_together = (cls._mptt_meta.tree_id_attr, cls._mptt_meta.left_attr)
-                if index_together not in cls._meta.index_together:
-                    cls._meta.index_together += (index_together,)
+                append_indexes(cls)
 
             # Add a tree manager, if there isn't one already
             if not abstract:
@@ -397,13 +396,7 @@ class MPTTModelBase(ModelBase):
                                 break
 
                 if is_cls_tree_model:
-                    idx_together = (
-                        cls._mptt_meta.tree_id_attr,
-                        cls._mptt_meta.left_attr,
-                    )
-
-                    if idx_together not in cls._meta.index_together:
-                        cls._meta.index_together += (idx_together,)
+                    append_indexes(cls)
 
                 if tree_manager and tree_manager.model is not cls:
                     tree_manager = tree_manager._copy_to_model(cls)

--- a/tests/myapp/models.py
+++ b/tests/myapp/models.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 from django.db import models
 from django.db.models import Field
+from django.db.models.indexes import Index
 from django.db.models.query import QuerySet
 
 import mptt
@@ -38,7 +39,6 @@ class Category(MPTTModel):
 
 
 class Item(models.Model):
-
     name = models.CharField(max_length=100)
     category_fk = models.ForeignKey(
         "Category",
@@ -391,3 +391,12 @@ class NotConcreteFieldModel(MPTTModel):
         "self", null=True, blank=True, related_name="children", on_delete=models.CASCADE
     )
     not_concrete_field = FakeNotConcreteField()
+
+
+class CustomIndexModel(MPTTModel):
+    """Adding this custom index"""
+
+    class MPTTMeta:
+        indexes = [Index(fields=["tree_id", "lft", "rght"])]
+
+    parent = TreeForeignKey("self", null=True, on_delete=models.CASCADE)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38,39}-dj{22,30,31}
-    py{38,39,310}-dj{32,40,41,main}
+    py{38,39,310}-dj{32,40,41,42,main}
     style
 
 [testenv]
@@ -17,6 +17,7 @@ deps =
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
+    dj42: Django>=4.2,<4.3
     djmain: https://github.com/django/django/archive/main.tar.gz
     model-bakery
     model-mommy

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     dj32: Django>=3.2,<4.0
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
-    dj42: Django>=4.2,<4.3
+    dj42: Django>=4.2,<5.0
     djmain: https://github.com/django/django/archive/main.tar.gz
     model-bakery
     model-mommy


### PR DESCRIPTION
[index_together](https://docs.djangoproject.com/en/4.2/ref/models/options/#index-together) is deprecated since django 4.2

This PR changes the way how indexes are append to the model. It converts the indexes from the `index_together` attribute to the new [Index](https://docs.djangoproject.com/en/4.2/ref/models/indexes/#index-options) objects to add backward compatibility.

Cause the mptt specific fiels are not available on django checks, i implemented a new MPTTMeta option to provide custom Indexes. This is a bit hacky, cause there is a reason, why django proofs the indexes on that early time.

However, in my pov there is still the need of using this mptt package, cause other alternative packages does not fit all edge cases which are covered by this package. As discussed in https://github.com/matthiask/django-tree-queries/issues/54, it is hard to prefetch all ancestors per node without mptt. You can do it with [django-treebeard](https://pypi.org/project/django-treebeard/). But the nested set implementation of django-treebeard does not adds a parent foreignkey. The foreignkey makes it possible to select the related parent per node.
