### PR TITLE
Create codespell_and_ruff.yml

### DIFF
--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: pip install --user codespell[toml] ruff
-    - run: codespell --ignore-words-list=aditional,envirnoment,mangement,trough,whet --skip="*.po,./mptt/models.py"
+    - run: codespell --ignore-words-list=whet --skip="*.po,./mptt/models.py"
     - run: ruff --output-format=github || true

--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -1,0 +1,19 @@
+# This Action uses minimal steps to run in ~5 seconds to rapidly:
+# look for typos in the codebase using codespell, and
+# lint Python code using ruff and provide intuitive GitHub Annotations to contributors.
+# https://github.com/codespell-project/codespell#readme
+# https://docs.astral.sh/ruff/
+name: codespell_and_ruff
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  codespell_and_ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: pip install --user codespell[toml] ruff
+    - run: codespell --ignore-words-list=aditional,envirnoment,mangement,trough,whet --skip="*.po,./mptt/models.py"
+    - run: ruff --output-format=github || true

--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -434,7 +434,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
            descendants, otherwise it will be for each item itself.
 
         ``extra_filters``
-           Dict with aditional parameters filtering the related queryset.
+           Dict with additional parameters filtering the related queryset.
         """
         if extra_filters is None:
             extra_filters = {}
@@ -974,7 +974,7 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
         database.
 
         Since we use tree ids to reduce the number of rows affected by
-        tree mangement during insertion and deletion, root nodes are not
+        tree management during insertion and deletion, root nodes are not
         true siblings; thus, making an item a sibling of a root node is
         a special case which involves shuffling tree ids around.
         """

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -1171,7 +1171,7 @@ class MPTTModel(models.Model, metaclass=MPTTModelBase):
 
 def _check_no_testing_generators(self):
     """Check that we are not generationg model from model_mommy or model_bakery"""
-    if sys.argv[1:2] == ["test"]:  # in testing envirnoment
+    if sys.argv[1:2] == ["test"]:  # in testing environment
         curframe = inspect.currentframe()
         call_frame = inspect.getouterframes(curframe, 0)
         call_file = call_frame[5][1]

--- a/mptt/static/mptt/draggable-admin.js
+++ b/mptt/static/mptt/draggable-admin.js
@@ -145,7 +145,7 @@ django.jQuery(function ($) {
               $("body").append('<div id="drag-line"><span></span></div>')
             }
 
-            // loop trough all rows
+            // loop through all rows
             $("tr", originalRow.parent()).each(function (index, el) {
               var element = $(el),
                 top = element.offset().top,


### PR DESCRIPTION
This GitHub Action uses minimal steps to run in ~5 seconds to rapidly:
* look for typos in the codebase using codespell, and
* lint Python code using ruff and provide intuitive GitHub Annotations to contributors.

https://github.com/codespell-project/codespell#readme
https://docs.astral.sh/ruff/

% `ruff --output-format=github || true`
TODO: After this PR is merged, fix the ruff issues and remove `|| true`