### PR TITLE
Update manager to support custom parent name

### DIFF
--- a/mptt/managers.py
+++ b/mptt/managers.py
@@ -646,8 +646,8 @@ class TreeManager(models.Manager.from_queryset(TreeQuerySet)):
             qs = qs.order_by(*opts.order_insertion_by)
 
         children = defaultdict(list)
-        for child in qs.select_related("parent"):
-            children[child.parent.pk].append(child)
+        for child in qs.select_related(opts.parent_attr):
+            children[getattr(child, opts.parent_attr).pk].append(child)
         return children
 
     @delegate_manager


### PR DESCRIPTION
Currently a harcoded 'parent' attribute is used for the lookup. If you use the Meta attribute parent_attr (our code base uses this for legacy schema reasons) this breaks.