### PR TITLE
docs: fix indentation for mptt_level_indent

### DIFF
--- a/docs/admin.rst
+++ b/docs/admin.rst
@@ -189,5 +189,5 @@ to ``10``)::
 
     # ...
     class MyTreeRelatedFieldListFilter(TreeRelatedFieldListFilter):
-    mptt_level_indent = 20
+        mptt_level_indent = 20
     # ...


### PR DESCRIPTION
The code in the documentation seems to have the wrong indentation.