### PR TITLE
Remove duplicate index_together logic in MPTTModelBase

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -401,15 +401,6 @@ class MPTTModelBase(ModelBase):
                                 tree_manager = cls_manager
                                 break
 
-                if is_cls_tree_model and django.VERSION < (5,):
-                    idx_together = (
-                        cls._mptt_meta.tree_id_attr,
-                        cls._mptt_meta.left_attr,
-                    )
-
-                    if idx_together not in cls._meta.index_together:
-                        cls._meta.index_together += (idx_together,)
-
                 if tree_manager and tree_manager.model is not cls:
                     tree_manager = tree_manager._copy_to_model(cls)
                 elif tree_manager is None:


### PR DESCRIPTION
The `index_together` is already added in
https://github.com/django-mptt/django-mptt/blob/755b128657a2ea383282fcb42f0430815a89490d/mptt/models.py#L376-L385, under the guard `is_cls_tree_model`.
No need to repeat it under `if not is_abstract and is_cls_tree_model`.