### PR TITLE
Handle Django 5 indexes for MPTTModelBase

### DIFF
--- a/mptt/models.py
+++ b/mptt/models.py
@@ -401,15 +401,6 @@ class MPTTModelBase(ModelBase):
                                 tree_manager = cls_manager
                                 break
 
-                if is_cls_tree_model and django.VERSION < (5,):
-                    idx_together = (
-                        cls._mptt_meta.tree_id_attr,
-                        cls._mptt_meta.left_attr,
-                    )
-
-                    if idx_together not in cls._meta.index_together:
-                        cls._meta.index_together += (idx_together,)
-
                 if tree_manager and tree_manager.model is not cls:
                     tree_manager = tree_manager._copy_to_model(cls)
                 elif tree_manager is None:

--- a/mptt/models.py
+++ b/mptt/models.py
@@ -4,9 +4,9 @@ import sys
 import threading
 from functools import reduce, wraps
 
-import django
 from django.conf import settings
 from django.db import models
+from django.db.backends.utils import truncate_name
 from django.db.models.base import ModelBase
 from django.db.models.query import Q
 from django.db.models.query_utils import DeferredAttribute
@@ -373,16 +373,24 @@ class MPTTModelBase(ModelBase):
                         )
                         field.contribute_to_class(cls, field_name)
 
-                if django.VERSION < (5,):
-                    # Add an index_together on tree_id_attr and left_attr, as these are very
-                    # commonly queried (pretty much all reads).
-                    # Django 5.0 (or 5.1?) only accepts Meta.indexes
-                    index_together = (
-                        cls._mptt_meta.tree_id_attr,
-                        cls._mptt_meta.left_attr,
+                index_fields = (
+                    cls._mptt_meta.tree_id_attr,
+                    cls._mptt_meta.left_attr,
+                )
+                for index in cls._meta.indexes:
+                    if tuple(index.fields) == index_fields:
+                        break
+                else:
+                    cls._meta.indexes.append(
+                        models.Index(
+                            fields=index_fields,
+                            name=truncate_name(
+                                f"{cls._meta.app_label}_{cls._meta.model_name}_"
+                                f"{cls._mptt_meta.tree_id_attr}_{cls._mptt_meta.left_attr}_idx",
+                                models.Index.max_name_length,
+                            ),
+                        )
                     )
-                    if index_together not in cls._meta.index_together:
-                        cls._meta.index_together += (index_together,)
 
             # Add a tree manager, if there isn't one already
             if not abstract:

--- a/tests/myapp/tests.py
+++ b/tests/myapp/tests.py
@@ -9,7 +9,7 @@ from django.apps import apps
 from django.contrib.admin import ModelAdmin, site
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.auth.models import Group, User
-from django.db.models import Q
+from django.db.models import Index, Q
 from django.db.models.query_utils import DeferredAttribute
 from django.template import Context, Template, TemplateSyntaxError
 from django.test import RequestFactory, TestCase, override_settings
@@ -2989,16 +2989,24 @@ class ModelMetaIndexes(TreeTestCase):
             field_name = getattr(SomeModel._mptt_meta, key)
             self.assertFalse(SomeModel._meta.get_field(field_name).db_index)
 
-    @unittest.skipUnless(django.VERSION < (5,), "Django 5 only accepts Meta.indexes")
-    def test_index_together(self):
-        already_idx = [["tree_id", "lft"], ("tree_id", "lft")]
+    @staticmethod
+    def index_fields(model):
+        return (tuple(index.fields) for index in model._meta.indexes)
+
+    def test_indexes(self):
+        already_idx = [
+            [
+                Index(fields=["tree_id", "lft"], name="original_idx"),
+                Index(fields=["tree_id", "lft"], name="duplicate_idx"),
+            ],
+        ]
         no_idx = [(), []]
-        some_idx = [["tree_id"], ("tree_id",), [["tree_id"]], (("tree_id",),)]
+        some_idx = [[Index(fields=["tree_id"], name="test_some_idx")]]
 
         for idx, case in enumerate(already_idx + no_idx + some_idx):
 
             class Meta:
-                index_together = case
+                indexes = case
                 app_label = "myapp"
 
             # Use type() here and in test_index_together_different_attr over
@@ -3016,13 +3024,17 @@ class ModelMetaIndexes(TreeTestCase):
                 },
             )
 
-            self.assertIn(("tree_id", "lft"), SomeModel._meta.index_together)
+            self.assertIn(("tree_id", "lft"), self.index_fields(SomeModel))
 
-    @unittest.skipUnless(django.VERSION < (5,), "Django 5 only accepts Meta.indexes")
     def test_index_together_different_attr(self):
-        already_idx = [["abc", "def"], ("abc", "def")]
+        already_idx = [
+            [
+                Index(fields=["abc", "def"], name="original_idx"),
+                Index(fields=("abc", "def"), name="duplicate_idx"),
+            ]
+        ]
         no_idx = [(), []]
-        some_idx = [["abc"], ("abc",), [["abc"]], (("abc",),)]
+        some_idx = [[Index(fields=["abc"], name="some_idx")]]
 
         for idx, case in enumerate(already_idx + no_idx + some_idx):
 
@@ -3031,7 +3043,7 @@ class ModelMetaIndexes(TreeTestCase):
                 left_attr = "def"
 
             class Meta:
-                index_together = case
+                indexes = case
                 app_label = "myapp"
 
             SomeModel = type(
@@ -3040,7 +3052,7 @@ class ModelMetaIndexes(TreeTestCase):
                 {"MPTTMeta": MPTTMeta, "Meta": Meta, "__module__": str(__name__)},
             )
 
-            self.assertIn(("abc", "def"), SomeModel._meta.index_together)
+            self.assertIn(("abc", "def"), self.index_fields(SomeModel))
 
 
 class BulkLoadTests(TestCase):


### PR DESCRIPTION
The `indexes` interface superseded `index_together`, and is available since Django 1.11.
https://docs.djangoproject.com/en/dev/releases/1.11/#class-based-model-indexes