### PR TITLE
Add Python 3.14 to the testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,8 @@ name: Tests
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
   pull_request:
   schedule:
     - cron: "37 1 1 * *"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,16 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.14"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,8 @@ name: Tests
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
   pull_request:
   schedule:
     - cron: "37 1 1 * *"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Change log
 Next version
 ============
 
+- Added support for Django 6.0.
+
 0.18
 ====
 

--- a/tests/myapp/test_forms.py
+++ b/tests/myapp/test_forms.py
@@ -1,6 +1,15 @@
+import django
 from django.forms.models import modelform_factory
 from myapp.models import Category, Genre, ReferencingModel
 from myapp.tests import TreeTestCase
+
+# Django 6.2 changed the default empty choice label from "---------" to
+# "- Select an option -". django-upgrade will remove this branch once we drop
+# support for Django < 6.2.
+if django.VERSION < (6, 2):
+    EMPTY_LABEL = "---------"
+else:
+    EMPTY_LABEL = "- Select an option -"
 
 from mptt.forms import (
     MoveNodeForm,
@@ -91,7 +100,7 @@ class TestForms(TreeTestCase):
         expected = (
             '<div><label for="id_target">Target:</label>'
             '<select name="target" size="10" id="id_target" required>'
-            '<option value="" selected>---------</option>'
+            f'<option value="" selected>{EMPTY_LABEL}</option>'
             '<option value="1"> Action</option>'
             '<option value="2">--- Platformer</option>'
             '<option value="3">------ 2D Platformer</option>'
@@ -136,7 +145,7 @@ class TestForms(TreeTestCase):
         self.assertHTMLEqual(
             field.widget.render("test", None),
             '<select name="test">'
-            '<option value="" selected>---------</option>'
+            f'<option value="" selected>{EMPTY_LABEL}</option>'
             '<option value="1"> Action</option>'
             '<option value="2">--- Platformer</option>'
             '<option value="3">------ 2D Platformer</option>'
@@ -163,7 +172,7 @@ class TestForms(TreeTestCase):
         self.assertHTMLEqual(
             field.widget.render("test", None),
             '<select name="test">'
-            '<option value="" selected>---------</option>'
+            f'<option value="" selected>{EMPTY_LABEL}</option>'
             '<option value="1"> Action</option>'
             '<option value="2">+-- Platformer</option>'
             '<option value="3">+--+-- 2D Platformer</option>'
@@ -184,7 +193,7 @@ class TestForms(TreeTestCase):
         self.assertHTMLEqual(
             field.widget.render("test", None),
             '<select name="test">'
-            '<option value="" selected>---------</option>'
+            f'<option value="" selected>{EMPTY_LABEL}</option>'
             '<option value="3">------ 2D Platformer</option>'
             '<option value="4">------ 3D Platformer</option>'
             '<option value="5">------ 4D Platformer</option>'
@@ -198,7 +207,7 @@ class TestForms(TreeTestCase):
         self.assertHTMLEqual(
             field.widget.render("test", None),
             '<select name="test">'
-            '<option value="" selected>---------</option>'
+            f'<option value="" selected>{EMPTY_LABEL}</option>'
             '<option value="2"> Platformer</option>'
             '<option value="3">--- 2D Platformer</option>'
             '<option value="4">--- 3D Platformer</option>'
@@ -213,7 +222,7 @@ class TestForms(TreeTestCase):
         self.assertHTMLEqual(
             field.widget.render("test", None),
             '<select name="test">'
-            '<option value="" selected>---------</option>'
+            f'<option value="" selected>{EMPTY_LABEL}</option>'
             '<option value="3"> 2D Platformer</option>'
             '<option value="4"> 3D Platformer</option>'
             '<option value="5"> 4D Platformer</option>'

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,12 @@
 [tox]
+# https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    py{39,310,311,312}-dj42
+    py{310,311,312}-dj42
     py{310,311,312}-dj50
-    py{310,311,312,313}-dj{51,52}
-    py{312,313}-djmain
+    py{310,311,312,313}-dj51
+    py{310,311,312,313,314}-dj52
+    py{312,313,314}-dj60
+    py{312,313,314}-djmain
     docs
 
 [testenv]
@@ -15,8 +18,9 @@ commands =
 deps =
     dj42: Django>=4.2,<5.0
     dj50: Django>=5.0,<5.1
-    dj51: Django>=5.0,<5.2
-    dj52: Django>=5.0,<6.0
+    dj51: Django>=5.1,<5.2
+    dj52: Django>=5.2,<6.0
+    dj60: Django>=6.0,<6.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     model-bakery
 


### PR DESCRIPTION
The cron tests are starting to fail on `djmain`: https://github.com/django-mptt/django-mptt/actions

https://docs.djangoproject.com/en/stable/faq/install/#what-python-version-can-i-use-with-django